### PR TITLE
Improve plot aesthetics of fancyplotting.py

### DIFF
--- a/example/fancyplotting.py
+++ b/example/fancyplotting.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
 
-""" A Python module to beauty the functionality of the FancyPlotting.nb
-    Mathematica code.
+"""
+fancyplotting.py -- make nice plots of tracts output.
+
+It mimics for the most part the output of fancyplotting.nb, but additionally
+provides a command-line interface and is generally more reusable that the
+originally-bundled Mathematica code.
+
+fancyplotting.py optionally uses seaborn or brewer2mpl if those packages are
+present in order to use their color palettes and otherwise make the plots look
+prettier. It is recommended -- although not necessary -- to install both of
+them.
 """
 
 from __future__ import print_function
+
+# We use semantic versioning. See http://semver.org/
+__version__ = '0.0.0.1'
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -47,7 +59,7 @@ def izip_with(fun, *args):
     """
     return (fun(*t) for t in zip(*args))
 
-# A strict version of zip_with
+# A strict version of izip_with
 zip_with = lambda fun, *args: list(izip_with(fun, *args))
 
 # Suffixing function factory: create a function that suffixes the supplied
@@ -290,8 +302,10 @@ if __name__ == "__main__":
     # For the theoretical prediction of each population, determine the lower
     # and upper bounds on the variability admitted by the theory.
     boundaries = [[(bin, find_bounds(expected_value, alpha))
-        for bin, expected_value in (np.array(pt) + 1e-9)] # TODO why this offset?
+        for bin, expected_value in (np.array(pt) + 1e-9)]
         for pt in plot_theories]
+    # the small offset 1e-9 is used to avoid the log-scale going too low,
+    # making things look bad.
 
 
     ### Make the figure ###

--- a/example/fancyplotting.py
+++ b/example/fancyplotting.py
@@ -51,10 +51,6 @@ suf = lambda s: lambda name: name + s
 # apply x f = flip id
 apply_to = lambda c: lambda f: f(c)
 
-# Curry a function by fixing the given constant as the function's first
-# parameter.
-c2 = lambda f, c: lambda *args: f(c, *args)
-
 # To parse a TSV file of floats given its path.
 parse_tsv = \
         lambda path: with_file(

--- a/example/fancyplotting.py
+++ b/example/fancyplotting.py
@@ -18,6 +18,14 @@ import sys
 
 colors = [(1.0, 0.0, 0.0), (0.0, 0.0, 1.0), (0.0, 1.0, 1.0)]
 
+#################
+### Constants ###
+#################
+
+# Parameter controlling how 'wide' the distribution should be, used to infer
+# the size of the distribution when drawing the plot
+alpha = 0.3173105078629141
+
 #########################################################
 ### Higher-order functions and combinators used later ###
 #########################################################
@@ -279,9 +287,6 @@ if __name__ == "__main__":
     ### Calculate the boundaries for the model prediction ###
     #########################################################
 
-    # parameter controlling how 'wide' the distribution should be
-    alpha = 0.3173105078629141
-
     # For the theoretical prediction of each population, determine the lower
     # and upper bounds on the variability admitted by the theory.
     boundaries = [[(bin, find_bounds(expected_value, alpha))
@@ -299,6 +304,7 @@ if __name__ == "__main__":
     #######################
 
     p = path.join(output_dir, "%s_plot.%s" % (name, plot_format))
+
     if not overwrite_plot: # if we care about preserving existing plots
         i = 1
         while path.exists(p):

--- a/example/matplotlibrc
+++ b/example/matplotlibrc
@@ -1,0 +1,10 @@
+font.family        : serif
+font.serif         : Times, Palatino, New Century Schoolbook, Bookman, Computer Modern Roman
+font.sans-serif    : Helvetica, Avant Garde, Computer Modern Sans serif
+font.cursive       : Zapf Chancery
+font.monospace     : Courier, Computer Modern Typewriter
+
+text.usetex        : True
+text.latex.unicode : True
+
+ps.usedistiller    : xpdf


### PR DESCRIPTION
The preliminary plotting module included in the previous pull request has been extended, and I consider it now production-ready. In particular, it optionally uses some nice Python libraries for making matplotlib figures much prettier, namely seaborn[1] and brewer2mpl[2], since, as we know, matplotlib's defaults are notoriously bad. This PR also bundles a matplotlibrc enabling LaTeX-rendered text. The command-line interface of the module now also allows optionally not producing a figure legend.