### PR TITLE
Composite demographic model

### DIFF
--- a/example/2pops/validate.py
+++ b/example/2pops/validate.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import sys, os, json
+
+sys.path.append('../..')
+sys.path.append('..')
+
+import tracts, pp, pp_px
+
+import FancyPlot as fp
+import numpy as np
+
+from glob import glob
+from collections import defaultdict
+
+eprint = lambda *args, **kwargs: print(*args, file=sys.stderr, **kwargs)
+
+# The haplotype specifiers, which are used in the path specifier for
+# identifying files to load.
+haplotype_spec = ('A', 'B')
+
+# The path specifier, which is a pattern into which we interpolate the
+# individual identifier and the haplotype specifier.
+pathspec = 'ind_%d_%s.bedx'
+
+# Identifiers given to the ancestries, as they appear in the .bed files.
+ancestry_labels = ('EUR', 'AFR')
+
+# A cutoff for bins with small counts of tracts.
+cutoff = 2
+
+names = [
+    "NA19700", "NA19701", "NA19704", "NA19703", "NA19819", "NA19818",
+    "NA19835", "NA19834", "NA19901", "NA19900", "NA19909", "NA19908",
+    "NA19917", "NA19916", "NA19713", "NA19982", "NA20127", "NA20126",
+    "NA20357", "NA20356"
+]
+
+def collect_paths(data_dir, pathspec):
+    """ Builds a list of tuples of paths corresponding to a list of paths
+        needed to build an individual in tracts.
+        Specifically, this method will, for increasing values of i starting at
+        1, file pairs of existing files whose name match the pathspec (a format
+        string) formatted by supplying the number i and the haplotype
+        specifier, in that order.
+        This is fairly naive and works only in the present case. A more robust
+        solution should be implemented later.
+    """
+    mkpath = lambda n, s: os.path.join(data_dir, pathspec % (n, s))
+
+    paths = []
+
+    i = 1
+    while True:
+        if os.path.exists(mkpath(i, haplotype_spec[0])):
+            paths.append(tuple(mkpath(i, s) for s in haplotype_spec))
+        else:
+            i -= 1
+            break
+        i += 1
+
+    eprint('found', i, 'individuals')
+
+    return paths
+
+def G10_paths(data_dir):
+    paths = []
+    for name in names:
+        paths.append(
+                tuple(
+                    os.path.join(data_dir, name + suf)
+                    for suf
+                    in ['_A.bed', '_B.bed']))
+    return paths
+
+def load_population(path_pairs):
+    """ Given a list of pairs of paths, each pair identifying the two
+        haplotypes for an individual, build a tracts population.
+    """
+    eprint('loading population')
+    return tracts.population([tracts.indiv.from_files(t) for t in path_pairs])
+
+def dual_analysis(labels, pop, migration_fun, migration_outofbounds_fun,
+        startparams, migration_fun_name):
+    """ Analyse a population using a given migration function, with both the
+        composite and classical models.
+    """
+
+    ## 1a. the composite demographic model.
+
+    # Get the information about the tracts out of the population object, and
+    # split the population into 2 groups, in order to perform an analysis as a
+    # composite demographic model.
+    bins, group_data = pop.get_global_tractlengths(npts=50, split_count=2)
+
+    # The actual groups that we're splitting the population into.
+    groups = pop.split_by_props(2)
+
+    # Compute the counts of individuals in each group and the average ancestry
+    # proportions across individuals. The counts of individuals in each groups
+    # should differ by no more than one.
+    ninds, group_ancestry_averages = zip(*map(
+        lambda p: (
+            len(p.indivs),
+            p.get_mean_ancestry_proportions(ancestry_labels)),
+        groups))
+
+    # Rearrange the data for each group into a list ordered in the same way as
+    # the population labels.
+    group_data = [
+            [g[ancestry_label] for ancestry_label in ancestry_labels]
+            for g in group_data]
+
+    ## Optimize the model parameters using COBYLA
+    #composite_model_parameters = tracts.optimize_cob_multifracs(
+    #        startparams, bins, pop.Ls, group_data, ninds, migration_fun,
+    #        group_ancestry_averages, outofbounds_fun=migration_outofbounds_fun,
+    #        cutoff=cutoff, epsilon=1e-12)
+
+    # Optimize the model parameters using brute
+    composite_model_parameters, _ = tracts.optimize_brute_multifracs(
+            bins, pop.Ls, group_data, ninds, migration_fun,
+            group_ancestry_averages, startparams,
+            outofbounds_fun=migration_outofbounds_fun,
+            cutoff=cutoff)
+
+    # Construct the composite demographic model
+    composite_model = tracts.composite_demographic_model(
+            migration_fun, composite_model_parameters,
+            group_ancestry_averages)
+
+
+    ## 1b. the fracs2 model.
+
+    nind = len(pop.indivs)
+
+    _, data = pop.get_global_tractlengths(npts=50, split_count=1)
+    data = [data[ancestry_label] for ancestry_label in ancestry_labels]
+
+    ancestry_averages = pop.get_mean_ancestry_proportions(ancestry_labels)
+
+    fracs2_model_parameters, _ = tracts.optimize_brute_fracs2(
+            bins, pop.Ls, data, nind,
+            migration_fun, ancestry_averages, startparams,
+            outofbounds_fun=migration_outofbounds_fun, cutoff=cutoff)
+
+    fracs2_model = tracts.demographic_model(
+            migration_fun(fracs2_model_parameters, ancestry_averages))
+
+    return {
+            'classical': {
+                'params': fracs2_model_parameters,
+                'model': fracs2_model,
+                'averages': ancestry_averages,
+                'theories': dict(
+                    (
+                        name,
+                        fp.Theory(
+                            bins,
+                            nind * np.array(
+                                fracs2_model.expectperbin(
+                                    pop.Ls, i, bins)),
+                            migration_fun_name + ' classical',
+                            name)
+                    )
+                    for i, name in enumerate(labels)),
+            },
+            'composite': {
+                'params': composite_model_parameters,
+                'model': composite_model,
+                'ninds': ninds,
+                'averages': group_ancestry_averages,
+                'groups': group_data,
+                'theories': dict(
+                    (
+                        name,
+                        fp.Theory(
+                            bins,
+                            composite_model.expectperbin(
+                                pop.Ls, i, bins, ninds),
+                            migration_fun_name + ' composite',
+                            name)
+                    )
+                    for i, name in enumerate(labels)),
+            },
+            'misc': {
+                'startparams': startparams,
+                'bins': bins,
+                'data': data,
+                'fun': migration_fun,
+            },
+    }
+
+def combine(d):
+    """ Takes a dictionary ModelName -> ModelData and joins it into something
+        with less redundancy and consisting only of serializable data.
+        The name of the model should be such that we can load the corresponding
+        function back from an eponymous file.
+        For example, if the name is "pp", then we should find a file called
+        "pp.py" with a function "pp_fix" in it that we can call to compute a
+        migration matrix according to that model.
+    """
+    q = {}
+    for name, data in d.iteritems():
+        if 'misc' not in q:
+            del data['misc']['fun']
+            del data['misc']['startparams']
+            data['misc']['bins'] = list(data['misc']['bins'])
+            q['misc'] = data['misc']
+            q['misc']['bins'] = list(q['misc']['bins'])
+        else:
+            del data['misc']
+        del data['classical']['model'] # nor demographic_model
+        del data['composite']['model'] # nor composite_demographic_model
+        del data['classical']['theories'] # nor FancyPlot Thoery
+        del data['composite']['theories']
+        data['classical']['params'] = list(data['classical']['params'])
+        data['composite']['params'] = list(data['composite']['params'])
+        q[name] = data
+    return q
+
+def main(data_dir, output_dir, pathspec):
+    if pathspec == 'G10' or not pathspec:
+        pop = load_population(G10_paths(data_dir))
+    else:
+        # load the population
+        pop = load_population(collect_paths(data_dir, pathspec))
+
+    nind = len(pop.indivs)
+
+
+    # do the analyses
+
+    pp_data = dual_analysis(ancestry_labels, pop, pp.pp_fix,
+            pp.outofbounds_pp_fix, (slice(0.02, 0.06, 0.005),), 'pp')
+
+    pp_px_data = dual_analysis(ancestry_labels, pop, pp_px.pp_px_fix,
+            pp_px.outofbounds_pp_px_fix,
+            (slice(0.02, 0.06, 0.01),
+                slice(0.005, 0.04, 0.01),
+                slice(0.01, 0.04, 0.01)),
+            'pp_px')
+
+    bins = pp_data['misc']['bins']
+    ninds = pp_data['composite']['ninds']
+
+
+    # Plotting
+
+    eprint("plotting pp migration function... ", end='')
+
+    pp_plot = fp.FancyPlot([
+        fp.Population(bins, pp_data['misc']['data'][i], name)
+            .add_theory(pp_data['classical']['theories'][name])
+            .add_theory(pp_data['composite']['theories'][name])
+        for i, name in enumerate(ancestry_labels)])
+
+    pp_plot.bottom_limit = 0.45
+
+    pp_plot.make_figure().savefig(output_dir + '_pp_validate.pdf')
+
+    eprint("done")
+
+    eprint("plotting pp_px migration function... ", end='')
+
+    pp_px_plot = fp.FancyPlot([
+        fp.Population(bins, pp_data['misc']['data'][i], name)
+            .add_theory(pp_px_data['classical']['theories'][name])
+            .add_theory(pp_px_data['composite']['theories'][name])
+        for i, name in enumerate(ancestry_labels)])
+
+    pp_px_plot.bottom_limit = 0.45
+
+    pp_px_plot.make_figure().savefig(output_dir + '_pp_px_validate.pdf')
+
+    eprint("done")
+
+    eprint("plotting pp vs pp_px for classical model... ", end='')
+
+    pp_vs_pp_px_plot_classical = fp.FancyPlot([
+        fp.Population(bins, pp_data['misc']['data'][i], name)
+            .add_theory(pp_data['classical']['theories'][name])
+            .add_theory(pp_px_data['classical']['theories'][name])
+        for i, name in enumerate(ancestry_labels)])
+
+    pp_vs_pp_px_plot_classical.bottom_limit = 0.45
+
+    pp_vs_pp_px_plot_classical.make_figure().savefig(
+            output_dir + '_pp_vs_pp_px_classical.pdf')
+
+    eprint("done")
+
+    eprint("plotting pp vs pp_px for composite model... ", end='')
+
+    pp_vs_pp_px_plot_composite = fp.FancyPlot([
+        fp.Population(bins, pp_data['misc']['data'][i], name)
+            .add_theory(pp_data['composite']['theories'][name])
+            .add_theory(pp_px_data['composite']['theories'][name])
+        for i, name in enumerate(ancestry_labels)])
+
+    pp_vs_pp_px_plot_composite.bottom_limit = 0.45
+
+    pp_vs_pp_px_plot_composite.make_figure().savefig(
+            output_dir + '_pp_vs_pp_px_composite.pdf')
+
+    eprint("done")
+
+    eprint("writing migration matrices... ", end='')
+
+    def write_migs(d, prefix):
+        """ Using the given path prefix, this method generates a migration
+            matrix file for the classical model and one migration matrix
+            file for each component demographic model of a composite model.
+            The argument "d" should be a dictionary produced by the
+            "dual_analysis" function.
+            Returns the list of files written.
+        """
+        names = [prefix+ '_classical_mig']
+
+        with open(prefix + '_classical_mig', 'wt') as f:
+            for line in d['classical']['model'].mig:
+                f.write('\t'.join(map(str, line)) + '\n')
+
+        for i, mig in enumerate(d['composite']['model'].migs()):
+            path = prefix + '_composite_mig_%d' % (i,)
+            names.append(path)
+            with open(path, 'wt') as f:
+                for line in mig:
+                    f.write('\t'.join(map(str, line)) + '\n')
+
+        return names
+
+    wrote = write_migs(pp_data, output_dir + '_pp')
+    wrote.extend(write_migs(pp_px_data, output_dir + '_pp_px'))
+
+    eprint("wrote", ', '.join(wrote))
+
+    # Compute the model likelihoods and save them
+
+    pp_data['classical']['lik'] = pp_data['classical']['model'].loglik(
+            bins, pop.Ls, pp_data['misc']['data'], nind, cutoff=cutoff)
+
+    pp_data['composite']['lik'] = pp_data['composite']['model'].loglik(
+            bins, pop.Ls, pp_data['composite']['groups'],
+            pp_data['composite']['ninds'], cutoff=cutoff)
+
+    pp_px_data['classical']['lik'] = pp_px_data['classical']['model'].loglik(
+            bins, pop.Ls, pp_data['misc']['data'], nind, cutoff=cutoff)
+
+    pp_px_data['composite']['lik'] = pp_px_data['composite']['model'].loglik(
+            bins, pop.Ls, pp_data['composite']['groups'],
+            pp_data['composite']['ninds'], cutoff=cutoff)
+
+    def write_liks(f):
+        print("pp classical", pp_data['classical']['lik'],
+                sep='\t', file=f)
+        print("pp composite", pp_data['composite']['lik'],
+                sep='\t', file=f)
+        print("pp_px classical", pp_px_data['classical']['lik'],
+                sep='\t', file=f)
+        print("pp_px composite", pp_px_data['composite']['lik'],
+                sep='\t', file=f)
+
+    print("likelihoods:")
+    write_liks(sys.stdout)
+    with open(output_dir + '_lik', 'wt') as f:
+        write_liks(f)
+
+    with open(output_dir + '_bins', 'wt') as f:
+        f.write('\t'.join(map(str, pp_data['misc']['bins'])) + '\n')
+
+    with open(output_dir + '_dat', 'wt') as f:
+        for i in xrange(len(ancestry_labels)):
+            f.write('\t'.join(map(str, pp_data['misc']['data'][i])) + '\n')
+
+    # Combine the pp and pp_px data into one JSON-serializable dict and save
+    # it.
+    q = combine({
+        'pp': pp_data,
+        'pp_px': pp_px_data,
+    })
+
+    with open(output_dir + 'result.json', 'wt') as f:
+        json.dump(q, f)
+
+    print('Done. Have a nice day.')
+
+if __name__ == '__main__':
+    # "Parse" command line arguments.
+
+    try:
+        data_dir = sys.argv[1]
+    except IndexError:
+        data_dir = 'G10/'
+
+    try:
+        output_dir = sys.argv[2]
+    except IndexError:
+        output_dir = './all_fix'
+
+    try:
+        pathspec = sys.argv[3]
+    except:
+        pathspec = ''
+
+    main(data_dir, output_dir, pathspec)

--- a/example/FancyPlot.py
+++ b/example/FancyPlot.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python
+
+# We use semantic versioning. See http://semver.org/
+__version__ = '0.0.0.1'
+
+import numpy as np
+import matplotlib.pyplot as plt
+import operator as op
+import os.path as path
+
+from scipy.stats import poisson
+from itertools import imap
+from collections import namedtuple
+
+import sys
+
+#################
+### Constants ###
+#################
+
+# Parameter controlling how 'wide' the distribution should be, used to infer
+# the size of the distribution when drawing the plot
+alpha = 0.3173105078629141
+
+#########################################################
+### Higher-order functions and combinators used later ###
+#########################################################
+
+def with_file(fun, path, mode='r'):
+    """ Run a function on the handle that results from opening the file
+        identified by the given path with the given mode.
+        When the function completes, the file handle is automatically closed.
+        Resource cleanup is ensured in the case of exceptions.
+    """
+    with open(path, mode) as handle:
+        return fun(handle)
+
+# To parse a TSV file of floats given its path.
+parse_tsv = \
+        lambda path: with_file(
+            lambda handle: map(
+                lambda line: map(
+                    float,
+                    line.strip().split('\t')),
+                handle),
+            path)
+
+#######################################################################
+### Functions for finding out the dispersion intervals for the plot ###
+#######################################################################
+
+def find_bounds(mean, alpha):
+    """ Find both the lower and upper bounds for a given mean value and
+        dispersion parameter in a poisson distribution.
+    """
+    fun = poisson(mu=mean).cdf
+
+    upper = None
+    lower = None
+
+    i = 0
+    while True:
+        if upper is None and fun(i) > 1 - alpha / 2.0:
+            upper = i
+        if lower is None and fun(i) > alpha / 2.0:
+            lower = i
+        if upper is not None and lower is not None:
+            return lower, upper
+        i += 1
+
+#####################################################
+### Classes that represent the data to be plotted ###
+#####################################################
+
+class Theory(object):
+    """ Represents an inference as made by tracts for a single population. """
+
+    @staticmethod
+    def load(path, bins, model_name, pop_names=['']):
+        """ From a '_pred' file as created by tracts, generate a list of Theory
+            objects.
+        """
+        theories = parse_tsv(path)
+
+        return [Theory(bins, t, model_name, name)
+                for t, name in zip(theories, pop_names)]
+
+    def __init__(self, bins, theory, model_name, pop_name):
+        self.theory = theory
+        self.model_name = model_name
+        self.pop_name = pop_name
+        self.bins = bins
+
+        self.boundary = [
+                find_bounds(expected_value, alpha)
+                for expected_value in (np.array(self.theory) + 1e-9)]
+
+        Y1, Y2 = zip(*self.boundary)
+
+        self.X = bins
+        self.Y1 = Y1
+        self.Y2 = Y2
+
+    def draw(self, ax, color, fill_alpha=0.2, bin_scale=1.):
+        label = self.pop_name + ' ' + \
+                self.model_name.replace('_', '-') + ' model'
+        ax.fill_between(bin_scale * self.X[:-1], nonzero(self.Y1)[:-1],
+                nonzero(self.Y2)[:-1],
+                interpolate=False, alpha=fill_alpha, color=color)
+        ax.plot(bin_scale * self.X[:-1], self.theory[:-1], color=color,
+                label=label)
+
+class Population:
+    """ Represents the data used by tracts to perform an inference. """
+
+    @staticmethod
+    def load(dat_path, bins, names):
+        data = parse_tsv(dat_path)
+
+        return [Population(bins, d, name)
+                for name, d in zip(names, data)]
+
+    def __init__(self, bins, data, name):
+        self.bins = bins
+        self.data = data
+        self.name = name
+        self.theories = []
+
+    def add_theory(self, t):
+        self.theories.append(t)
+        return self
+
+    def draw(self, ax, base_color, theory_colors, bin_scale=1.):
+        for theory, color in zip(self.theories, theory_colors):
+            theory.draw(ax, color, bin_scale=bin_scale)
+
+        ax.scatter(bin_scale * self.bins[:-1], self.data[:-1],
+                color=base_color,
+                label=(self.name + " data").replace('_', '-'))
+
+class FancyPlot:
+    """ A fancy plot is a collection of Population objects, each of which is
+        populated with as many Theory objects as there are tracts runs to
+        compare.
+    """
+    @staticmethod
+    def load(bins_path, dat_path, pred_paths, pop_names, model_names):
+        """ Load a FancyPlot from a set of files, specifically the output from
+            tracts.
+
+            Arguments:
+                bins_path (string):
+                    The path to the '_bins' file.
+                dat_path (string):
+                    The path to the '_dat' file.
+                pred_paths (list of strings):
+                    Each element of pred_paths must be a path to a '_pred'
+                    file. Each '_pred' file describes an inference made by
+                    tracts for each population.
+                pop_names (list of strings):
+                    The names of the populations over which the inference was
+                    made.
+                model_names (list of strings):
+                    the names of the models used for the inferences. There
+                    should be as many model names as there are pred_paths.
+        """
+        bins = np.array(parse_tsv(bins_path)[0])
+        pops = Population.load(dat_path, bins, pop_names)
+
+        # each element of 'theories' is actually a list of Theory objects,
+        # which must be ordered as in pop_names.
+        theories = [Theory.load(p, bins, name, pop_names)
+                for p, name in zip(pred_paths, model_names)]
+
+        # hence, we transpose the theories list such that each element of
+        # 'theories_t' is a list of all the Theory objects associated with the
+        # corresponding population
+        theories_t = zip(*theories)
+
+        for p, ts in zip(pops, theories_t):
+            for t in ts:
+                p.add_theory(t)
+
+        return FancyPlot(pops)
+
+    def __init__(self, pops=[]):
+        self.populations = pops
+
+        self.title = 'Number of tracts vs tract length (cM)'
+        self.xlabel = 'tract length (cM)'
+        self.ylabel = 'number of tracts'
+        self.legend = True
+
+        self.top_limit = None
+        self.right_limit = None
+        self.bottom_limit = 0.92
+        self.left_limit = 0.0
+
+        self.bin_scale = 100
+
+    def __getitem__(self, k):
+        return self.populations[k]
+
+    def add_population(self, pop):
+        self.populations.append(pop)
+        return self
+
+    def choose_colors(self):
+        """ Based on the data to be shown by this FancyPlot, choose some nice
+            colors. A tuple (population colors, theory colors) is returned such
+            that its components can be supplied directly to FancyPlot.draw's
+            second and third arguments.
+        """
+        N = len(self.populations)
+        M = len(self.populations[0].theories)
+        nh_size = 1.0 / N
+        S = nh_size / 2
+        cmap = plt.get_cmap()
+
+        pop_colors = [(k, cmap(k))
+                for i, k
+                in enumerate(np.linspace(0.0, 1.0, 2*N+1))
+                if i % 2 != 0]
+
+        model_colors = [
+                [(k, cmap(k))
+                    for i, k
+                    in enumerate(np.linspace(j-S, j+S, 2*M+1))
+                    if i % 2 != 0]
+                for j, _
+                in pop_colors]
+
+        fst = lambda t: t[1]
+
+        return (map(fst, pop_colors),
+                map(lambda cs: map(fst, cs), model_colors))
+
+    def draw(self, ax, pop_colors, theory_colors):
+        """ Draw this FancyPlot onto an existing set of axes with the given
+            colors.
+        """
+        for pop, color, t_colors in \
+                zip(self.populations, pop_colors, theory_colors):
+            pop.draw(ax, color, t_colors, bin_scale=self.bin_scale)
+
+    def make_figure(self, pop_colors=None, theory_colors=None,
+            automatic_colors=True):
+        """ Create a figure from this FancyPlot.
+
+            Arguments:
+                pop_colors (list of RGBA tuples, default: None):
+                    The colors with which each population should be drawn,
+                    respectively. There should be at least as many colors in
+                    pop_colors as there are populations in this FancyPlot.
+                theory_colors (list of lists of RGBA tuples, default: None):
+                    The colors with which each theory should be drawn for each
+                    population. The first level of lists must contain as many
+                    elements as there are population in this FancyPlot. The
+                    inner lists must contain at least as many elements as the
+                    corresponding Population has Theory objects.
+                automatic_colors (boolean, default: True):
+                    When True, colors will be chosen automatically for the data
+                    represented by this FancyPlot.
+        """
+        if automatic_colors:
+            if pop_colors is not None or theory_colors is not None:
+                raise ValueError('When automatic_colors is True, both '
+                        'pop_colors and theory_colors must be given as None.')
+        else:
+            if pop_colors is None or theory_colors is None:
+                raise ValueError('When automatic_colors is False, both '
+                        'pop_colors and theory_colors must be given non-None '
+                        'values.')
+
+        fig = plt.figure()
+        fig.suptitle(self.title)
+        ax = fig.add_subplot(1, 1, 1)
+
+        # Set the axis labels
+        ax.set_xlabel(self.xlabel)
+        ax.set_ylabel(self.ylabel)
+
+        ax.set_yscale('log')
+
+        if automatic_colors:
+            pop_colors, theory_colors = self.choose_colors()
+
+        self.draw(ax, pop_colors, theory_colors)
+
+        if self.legend:
+            ax.legend()
+
+        ax.set_ylim(bottom=self.bottom_limit, top=self.top_limit)
+        ax.set_xlim(left=self.left_limit, right=self.right_limit)
+
+        return fig
+
+#####################
+### Miscellaneous ###
+#####################
+
+def nonzero(seq, cutoff=1e-9, offset=1e-9):
+    """ Any zeroes (values smaller than the cutoff) found in the given sequence
+        of numbers are offset by the given offset.
+    """
+    return [x + offset if x < cutoff else x for x in seq]


### PR DESCRIPTION
* The previously created fancyplotting script has been refactored into a library to facilitate generating plots at the end of a driver script.
* The `composite_demographic_model` class is implemented. Its API is essentially the same as the `demographic_model` class's. In fact, it is merely a wrapper around a list of `demographic_model` objects, and provides some methods for computing quantities based on the underlying `demographic_model` instances. For instance, a method is provided for computing the log-likelihood of the composite model by first combining the expectations of the component models.
* The existing `population` class has been extended with methods to split it according to ancestry proportions of its members. Specifically, the `get_global_tractlengths` method accepts an argument to control how many groups the population should be split into, and a `split_by_props` method is implemented to produce a list of new `population` objects representing the these groups.
* A driver script is included to showcase the use of the `composite_demographic_model` in conjunction with the existing `demographic_model` class. Fits are calculated for both the one-pulse (`pp`) and two-pulse (`pp_px`) models with both the `demographic_model` and `composite_demographic_model`.
* Some minor changes were also made to internal code in tracts. This should not affect any production code unless they were dealing directly with the internals of tracts. For example, one of these is a mostly cosmetic change, renaming `__uniformizemat__` to `uniformizemat`, as the double-underscore style names are reserved for very general methods in Python. Some of the changes provide a small performace boost; by using iterators instead of lists, unnecessary copies are avoided, and the memory footprint of tracts is reduced.