### PR TITLE
Set setuptools version to 68.2.2 to fix installation issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools==68.2.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Replace `requires = ["setuptools>=61.0"]` by `requires = ["setuptools==68.2.2"]` in `pyproject.toml` to fix the installation issue described [here](https://stackoverflow.com/questions/77523055/missingdynamic-license-defined-outside-of-pyproject-toml-is-ignored).