### PR TITLE
Update tractlength_histogram_windowed ouput

### DIFF
--- a/example/.ipynb_checkpoints/toy_example-checkpoint.ipynb
+++ b/example/.ipynb_checkpoints/toy_example-checkpoint.ipynb
@@ -11,9 +11,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "c33f835d",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Import required libraries\n",
     "import tracts.phase_type_distribution as PhT\n",
@@ -23,8 +24,7 @@
     "from matplotlib.ticker import FormatStrFormatter\n",
     "import matplotlib as mpl\n",
     "mpl.rcParams.update(mpl.rcParamsDefault)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -36,69 +36,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "cb8b3bca",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "whichpop = 0\n",
+    "whichpop = 1\n",
     "mig_matrix = np.array([[0, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0, 1]])"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "b1e04b1d",
    "metadata": {},
    "source": [
-    "In what follows, we compute Phase-Type densities and histograms under autosomal and X chromosome admixture, using all the models presented in tracts. We consider different levels of sex bias, in both migration and recombination rates."
+    "In what follows, we compute Phase-Type densities and histograms under autosomal and X chromosome admixture, using all the models presented in tracts. We consider different levels of sex bias, in both migration and recombination rates.\n",
+    "\n",
+    "### Note\n",
+    "The previous migration matrix represents a demographic model of 6 generations. This is a **toy framework** where all the presented models are computationally efficient and can be quickly computed and compared. \n",
+    "\n",
+    "For more realistic demographic models going up to 15-18 generations, the following models should be used depending on the context:\n",
+    "* For autosomal admixture: Dioecious-Coarse (DC) or Monoecious (M) model,\n",
+    "* For X chromosome adxmiture: Dioecious-Coarse (DC) model or its Hybrid-Pedigree refinement (Ped-DC). Tipically, the number of pedigree generations should be set to `TP=2`.\n",
+    "\n",
+    "An example under both settings is presented at the end of the notebook."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "200f82b2",
+   "id": "47919257",
    "metadata": {},
    "source": [
-    "### Choose autosomal or X chromosome admixture"
+    "### 1. Choose autosomal or X chromosome admixture"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "4306a0c3",
+   "execution_count": 3,
+   "id": "7cdca656",
    "metadata": {},
+   "outputs": [],
    "source": [
     "X_chr = False # Set to True for admixture on the X chromosome\n",
     "X_chr_male = False # Set to True if admixture is considered on the X chromosome of a male individual (only maternally inherited alleles)."
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "18dbbe56",
+   "execution_count": 4,
+   "id": "a88d4d00",
    "metadata": {},
+   "outputs": [],
    "source": [
     "which_L = 1.7928357829 # Second chromosome\n",
     "#which_L = 1.96 # For the X chromosome\n",
     "# Set a point grid on the finite chromosome\n",
     "bins = np.linspace(0, which_L+0.1, num = 50)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "d258daf1",
+   "id": "c2d1c82b",
    "metadata": {},
    "source": [
-    "### Set sex-bias\n",
+    "### 2. Set sex-bias\n",
     "The following parameters set the sex-bias for migration and recombination rates. The user can modify these parameters to observe how differences appear between all the considered models."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "3b8d0e8e",
+   "execution_count": null,
+   "id": "af95faed",
    "metadata": {},
+   "outputs": [],
    "source": [
     "prop_of_female_migration = 0.5 # 0.5 for unbiased migration, 1 for only female migrants, 0 for only male migrants.\n",
     "mig_m = 2*mig_matrix*(1-prop_of_female_migration)\n",
@@ -108,15 +118,14 @@
     "\n",
     "rec_f = 1 # Female-specific recombination rate\n",
     "rec_m = 1 # Male-specific recombination rate"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "8f21e0d4",
+   "id": "a16638fa",
    "metadata": {},
    "source": [
-    "### Compute model parameters and distributions\n",
+    "### 3. Compute model parameters and distributions\n",
     "For the Monoecious (M), Dioecious Fine (DF) and Dioecious Coarse (DC) models, we first compute a PhTMonoecious or PhTDioecious object, and then compute the Phase-Type density or histogram with a different function. For the Pedigree-Dioecious models, densities and histograms are computed directly from the model parameters.\n",
     "\n",
     "For comparison with the other settings, the Monoecious model is always computed using the mean migration matrix and the mean recombination rate."
@@ -124,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67ad6888",
+   "id": "8799a86c",
    "metadata": {},
    "source": [
     "#### Monoecious model (don't run for X chromosome)"
@@ -132,21 +141,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "9bf282f3",
+   "execution_count": null,
+   "id": "82b132b7",
    "metadata": {},
+   "outputs": [],
    "source": [
     "PTmodel_mono = PhT.PhTMonoecious(mig_matrix, rho = 0.5*(rec_f+rec_m)) # M object\n",
     "# Density (set freq = True for frequency scale)\n",
-    "newbins, density_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = False)\n",
+    "newbins, density_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
     "# Histogram\n",
-    "hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
-   ],
-   "outputs": []
+    "bins, hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "286ecabf",
+   "id": "f366998e",
    "metadata": {},
    "source": [
     "#### Dioecious Fine and Coarse models"
@@ -154,60 +163,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "cb2dcf16",
+   "execution_count": null,
+   "id": "fa5812c0",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# DF and DC objects\n",
     "PTmodel_DF = PhT.PhTDioecious(mig_f, mig_m, rho_f = rec_f, rho_m = rec_m, sex_model = 'DF', X_chromosome = X_chr, X_chromosome_male = X_chr_male)\n",
     "PTmodel_DC = PhT.PhTDioecious(mig_f , mig_m, rho_f = rec_f, rho_m = rec_m, sex_model = 'DC', X_chromosome = X_chr, X_chromosome_male = X_chr_male)\n",
     "# Densities (set freq = True for frequency scale)\n",
-    "newbins, density_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = False)\n",
-    "newbins, density_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = False)\n",
+    "newbins, density_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
+    "newbins, density_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
     "# Histograms\n",
-    "hist_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)\n",
-    "hist_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
-   ],
-   "outputs": []
+    "bins, hist_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)\n",
+    "bins, hist_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "064ea47e",
+   "id": "e692c16a",
    "metadata": {},
    "source": [
-    "#### Pedigree-Dioecious models"
+    "#### Hybrid-pedigree refinements"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "8672de97",
+   "execution_count": null,
+   "id": "d0b28cbf",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Phase-Type density for the Pedigree-DF model (set freq = True for frequency scale)\n",
-    "newbins, density_hp_df = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DF', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = True, freq = False)\n",
+    "newbins, density_hp_df = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DF', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = True, freq = True)\n",
     "# Phase-Type density for the Pedigree-DC model (set freq = True for frequency scale)\n",
-    "newbins, density_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = True, freq = False)\n",
+    "newbins, density_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = True, freq = True)\n",
     "# Phase-Type histogram for the Pedigree-DF model\n",
     "bins, hist_hp_df = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DF', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = False, freq = False)\n",
     "# Phase-Type histogram for the Pedigree-DC model\n",
     "bins, hist_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = False, freq = False)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "e8ef3641",
+   "id": "272badd3",
    "metadata": {},
    "source": [
-    "### Plot densities"
+    "### 4. Plot tract length distributions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "53798d3f",
+   "execution_count": null,
+   "id": "3b527680",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Color palette and line styles\n",
     "colors = {\n",
@@ -235,28 +245,36 @@
     "    'HP':2,\n",
     "    'HP_DC':2\n",
     "}"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "e1ebbf45",
+   "id": "6317c4ba",
+   "metadata": {},
+   "source": [
+    "### 4.1 Plot densities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a165d7a",
    "metadata": {},
    "source": [
     "#### Plot for autosomal admixture\n",
-    "The following code produces a figure depicting all the computed Phase-Type densities for autosomal admixture."
+    "The following code produces a figure depicting all the computed Phase-Type densities for autosomal admixture. Run if `X_chr = False`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "8a6e8961",
+   "execution_count": null,
+   "id": "6622fbb7",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
     "\n",
-    "fig, axes = plt.subplots(1, 1, figsize=(5,4))  # 3x3 grid of subplots\n",
+    "fig, axes = plt.subplots(1, 1, figsize=(5,4))  \n",
     "ax = axes  \n",
     "# Plot lines with improved color and line style\n",
     "line1, = ax.plot(np.delete(newbins, whichbin), (density_df[~(np.asarray(newbins) == outbin)]), color=colors['DF'], linestyle=line_styles['DF'], linewidth = line_widths['DF'],  label='Dioecious Fine (DF)', zorder = 1)\n",
@@ -269,7 +287,8 @@
     "        \n",
     "# Customize x and y labels\n",
     "ax.set_xlabel('Tract length on the second chromosome', fontsize=10)\n",
-    "ax.set_ylabel('Density', fontsize=10)\n",
+    "ax.set_ylabel('Frequency', fontsize=10)\n",
+    "#ax.set_ylabel('Density', fontsize=10)\n",
     "        \n",
     "# Add outlier point to the plot\n",
     "ax.scatter(outbin, (density_df[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['DF'], s=30, label='Outlier', marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
@@ -280,7 +299,7 @@
     "\n",
     "# Add outlier point to the plot\n",
     "ax.scatter(outbin, density_df[np.where(newbins == outbin)], edgecolor=colors['DF'], s=30, label='Outlier', marker='o', facecolor=colors['DF'], zorder = 4)\n",
-    "ax.scatter(outbin, density_hp_dc[np.where(newbins == outbin)], edgecolor=colors['DC'], s=30, label='Outlier',marker='o', facecolor=colors['DC'], zorder = 4)\n",
+    "ax.scatter(outbin, density_dc[np.where(newbins == outbin)], edgecolor=colors['DC'], s=30, label='Outlier',marker='o', facecolor=colors['DC'], zorder = 4)\n",
     "ax.scatter(outbin, density_m[np.where(newbins == outbin)], edgecolor=colors['M'], s=30, label='Outlier', marker='o', facecolor=colors['M'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_df[np.where(newbins == outbin)], edgecolor=colors['HP'], s=30, label='Outlier', marker='o', facecolor=colors['HP'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_df[np.where(newbins == outbin)], edgecolor=colors['HP'], s=15, label='Outlier', marker='o', facecolor=colors['DF'], zorder = 4)\n",
@@ -307,23 +326,23 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "e995b2bb",
+   "id": "ba7cde6f",
    "metadata": {},
    "source": [
     "#### Plot for X chromosome admixture\n",
-    "The following code produces a figure depicting all the computed Phase-Type densities for admixture on the X chromosome."
+    "The following code produces a figure depicting all the computed Phase-Type densities for admixture on the X chromosome. Run if `X_chr = True`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "id": "3b50abff",
+   "execution_count": null,
+   "id": "35660016",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -350,7 +369,7 @@
     "\n",
     "# Add outlier point to the plot\n",
     "ax.scatter(outbin, density_df[np.where(newbins == outbin)], edgecolor=colors['DF'], s=30, label='Outlier', marker='o', facecolor=colors['DF'], zorder = 4)\n",
-    "ax.scatter(outbin, density_hp_dc[np.where(newbins == outbin)], edgecolor=colors['DC'], s=30, label='Outlier',marker='o', facecolor=colors['DC'], zorder = 4)\n",
+    "ax.scatter(outbin, density_dc[np.where(newbins == outbin)], edgecolor=colors['DC'], s=30, label='Outlier',marker='o', facecolor=colors['DC'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_df[np.where(newbins == outbin)], edgecolor=colors['HP'], s=30, label='Outlier', marker='o', facecolor=colors['HP'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_df[np.where(newbins == outbin)], edgecolor=colors['HP'], s=15, label='Outlier', marker='o', facecolor=colors['DF'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_dc[np.where(newbins == outbin)], edgecolor=colors['HP_DC'], s=30, label='Outlier', marker='o', facecolor=colors['HP_DC'], zorder = 4)\n",
@@ -376,22 +395,317 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "c0bbf9b4",
+   "id": "4b429c31",
    "metadata": {},
    "source": [
-    "### Plot histograms"
+    "### 4.2 Plot histograms\n",
+    "#### Plot for autosomal admixture\n",
+    "The following code produces a figure depicting all the computed Phase-Type histograms for autosomal admixture. Run if `X_chr = False`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2f8daf9",
+   "id": "f6289e9b",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
+    "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5,4)) \n",
+    "\n",
+    "# Plot lines with improved color and line style\n",
+    "line1, = ax.step(bins[:-1], hist_df, color=colors['DF'], linestyle=line_styles['DF'], linewidth = line_widths['DF'],  label='Dioecious Fine (DF)')\n",
+    "line2, = ax.step(bins[:-1], hist_dc, color=colors['DC'], linestyle=line_styles['DC'], linewidth = line_widths['DC'], label='Dioecious Coarse (DC)')\n",
+    "line3, = ax.step(bins[:-1], hist_m, color=colors['M'], linestyle=line_styles['M'], linewidth = line_widths['M'], label='Monoecious (M)')\n",
+    "line4, = ax.step(bins[:-1], hist_hp_df, color=colors['HP'], linestyle=line_styles['HP'], linewidth = line_widths['HP'], label='Ped-DF (TP = 2)')\n",
+    "line5, = ax.step(bins[:-1], hist_hp_df, color=colors['DF'], linestyle=(2, (2, 2)), linewidth = line_widths['HP'], label='Ped-DF (TP = 2)')\n",
+    "line6, = ax.step(bins[:-1], hist_hp_dc, color=colors['HP_DC'], linestyle=line_styles['HP_DC'], linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)')\n",
+    "line7, = ax.step(bins[:-1], hist_hp_dc, color=colors['DC'], linestyle=(2, (2, 2)), linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)')\n",
+    "        \n",
+    "# Customize x and y labels\n",
+    "ax.set_xlabel('Tract length on the second chromosome', fontsize=10)\n",
+    "ax.set_ylabel('Expected number of tracts per interval', fontsize=10)\n",
+    "        \n",
+    "# Add gridlines\n",
+    "ax.grid(True, linestyle='--', alpha=0.6)\n",
+    "\n",
+    "# Set limits for x-axis and y-axis if necessary\n",
+    "ax.set_xlim(0, which_L+0.1)\n",
+    "\n",
+    "# Customize the ticks\n",
+    "ax.tick_params(axis='both', which='major', labelsize=10)\n",
+    "\n",
+    "handles = []\n",
+    "labels = []\n",
+    "handles.extend([line1, line2, line3, (line4, line5), (line6, line7)])\n",
+    "labels.extend([line1.get_label(), line2.get_label(), line3.get_label(), line4.get_label(), line6.get_label()])\n",
+    "\n",
+    "fig.legend(handles=handles, labels=labels, loc='lower center', bbox_to_anchor=(0.55, -0.2), ncol=2, fontsize=10)\n",
+    "\n",
+    "# Adjust spacing between subplots for better layout\n",
+    "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53c27763",
+   "metadata": {},
+   "source": [
+    "#### Plot for X chromosome admixture\n",
+    "The following code produces a figure depicting all the computed Phase-Type histograms for admixture on the X chromosome. Run if `X_chr = True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55af0c51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
+    "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5,4)) \n",
+    "\n",
+    "# Plot lines with improved color and line style\n",
+    "line1, = ax.step(bins[:-1], hist_df, color=colors['DF'], linestyle=line_styles['DF'], linewidth = line_widths['DF'],  label='Dioecious Fine (DF)')\n",
+    "line2, = ax.step(bins[:-1], hist_dc, color=colors['DC'], linestyle=line_styles['DC'], linewidth = line_widths['DC'], label='Dioecious Coarse (DC)')\n",
+    "line4, = ax.step(bins[:-1], hist_hp_df, color=colors['HP'], linestyle=line_styles['HP'], linewidth = line_widths['HP'], label='Ped-DF (TP = 2)')\n",
+    "line5, = ax.step(bins[:-1], hist_hp_df, color=colors['DF'], linestyle=(2, (2, 2)), linewidth = line_widths['HP'], label='Ped-DF (TP = 2)')\n",
+    "line6, = ax.step(bins[:-1], hist_hp_dc, color=colors['HP_DC'], linestyle=line_styles['HP_DC'], linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)')\n",
+    "line7, = ax.step(bins[:-1], hist_hp_dc, color=colors['DC'], linestyle=(2, (2, 2)), linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)')\n",
+    "        \n",
+    "# Customize x and y labels\n",
+    "ax.set_xlabel('Tract length on the X chromosome', fontsize=10)\n",
+    "ax.set_ylabel('Expected number of tracts per interval', fontsize=10)\n",
+    "        \n",
+    "# Add gridlines\n",
+    "ax.grid(True, linestyle='--', alpha=0.6)\n",
+    "\n",
+    "# Set limits for x-axis and y-axis if necessary\n",
+    "ax.set_xlim(0, which_L+0.1)\n",
+    "\n",
+    "# Customize the ticks\n",
+    "ax.tick_params(axis='both', which='major', labelsize=10)\n",
+    "\n",
+    "handles = []\n",
+    "labels = []\n",
+    "handles.extend([line1, line2, (line4, line5), (line6, line7)])\n",
+    "labels.extend([line1.get_label(), line2.get_label(), line4.get_label(), line6.get_label()])\n",
+    "\n",
+    "fig.legend(handles=handles, labels=labels, loc='lower center', bbox_to_anchor=(0.55, -0.2), ncol=2, fontsize=10)\n",
+    "\n",
+    "# Adjust spacing between subplots for better layout\n",
+    "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e1bc374",
+   "metadata": {},
+   "source": [
+    "## Tract length distribution for a continuous pulse during 15 generations\n",
+    "We consider the following migration matrix, and let the user specify the sex-bias parameters as in the previous example. Once again, `whichpop` sets the population of interest (0 or 1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27b9ea46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "whichpop = 1\n",
+    "mig_matrix = np.array([[0, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0, 1]])\n",
+    "print(np.shape(mig_matrix)[0]-1) # Number of generations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ad3818e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prop_of_female_migration = 0.5 # 0.5 for unbiased migration, 1 for only female migrants, 0 for only male migrants.\n",
+    "mig_m = 2*mig_matrix*(1-prop_of_female_migration)\n",
+    "mig_f = 2*mig_matrix*prop_of_female_migration\n",
+    "mig_m[-1,:] = mig_matrix[-1,:]\n",
+    "mig_f[-1,:] = mig_matrix[-1,:]\n",
+    "\n",
+    "rec_f = 1 # Female-specific recombination rate\n",
+    "rec_m = 1 # Male-specific recombination rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2af565c",
+   "metadata": {},
+   "source": [
+    "### Monoecious model for autosomal admixture"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae3b297b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PTmodel_mono = PhT.PhTMonoecious(mig_matrix, rho = 0.5*(rec_f+rec_m)) # M object\n",
+    "# Density (set freq = True for frequency scale)\n",
+    "newbins, density_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
+    "# Histogram\n",
+    "bins, hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b44b701d",
+   "metadata": {},
+   "source": [
+    "#### Plot density"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a3b8803",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
+    "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 1, figsize=(5,4))  \n",
+    "ax = axes  \n",
+    "# Plot lines with improved color and line style\n",
+    "line3, = ax.plot(np.delete(newbins, whichbin), (density_m[~(np.asarray(newbins) == outbin)]), color=colors['M'], linestyle=line_styles['M'], linewidth = line_widths['M'], label='Monoecious (M)', zorder = 1)\n",
+    "       \n",
+    "# Customize x and y labels\n",
+    "ax.set_xlabel('Tract length on the second chromosome', fontsize=10)\n",
+    "ax.set_ylabel('Frequency', fontsize=10)\n",
+    "#ax.set_ylabel('Density', fontsize=10)\n",
+    "        \n",
+    "# Add outlier point to the plot\n",
+    "ax.scatter(outbin, (density_m[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['M'], s=30, label='Outlier', marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
+    "\n",
+    "# Add outlier point to the plot\n",
+    "ax.scatter(outbin, density_m[np.where(newbins == outbin)], edgecolor=colors['M'], s=30, label='Outlier', marker='o', facecolor=colors['M'], zorder = 4)\n",
+    "\n",
+    "# Add gridlines\n",
+    "ax.grid(True, linestyle='--', alpha=0.6)\n",
+    "\n",
+    "# Set limits for x-axis and y-axis if necessary\n",
+    "ax.set_xlim(0, which_L+0.1)\n",
+    "\n",
+    "# Customize the ticks\n",
+    "ax.tick_params(axis='both', which='major', labelsize=10)\n",
+    "ax.yaxis.set_major_formatter(FormatStrFormatter('%.2f'))\n",
+    "\n",
+    "handles = []\n",
+    "labels = []\n",
+    "handles.extend([line3])\n",
+    "labels.extend([line3.get_label()])\n",
+    "\n",
+    "fig.legend(handles=handles, labels=labels, loc='lower center', bbox_to_anchor=(0.55, -0.2), ncol=2, fontsize=10)\n",
+    "\n",
+    "# Adjust spacing between subplots for better layout\n",
+    "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91f704e3",
+   "metadata": {},
+   "source": [
+    "#### Plot histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ff050fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
+    "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5,4)) \n",
+    "\n",
+    "# Plot lines with improved color and line style\n",
+    "line3, = ax.step(bins[:-1], hist_m, color=colors['M'], linestyle=line_styles['M'], linewidth = line_widths['M'], label='Monoecious (M)')\n",
+    "        \n",
+    "# Customize x and y labels\n",
+    "ax.set_xlabel('Tract length on the second chromosome', fontsize=10)\n",
+    "ax.set_ylabel('Expected number of tracts per interval', fontsize=10)\n",
+    "        \n",
+    "# Add gridlines\n",
+    "ax.grid(True, linestyle='--', alpha=0.6)\n",
+    "\n",
+    "# Set limits for x-axis and y-axis if necessary\n",
+    "ax.set_xlim(0, which_L+0.1)\n",
+    "\n",
+    "# Customize the ticks\n",
+    "ax.tick_params(axis='both', which='major', labelsize=10)\n",
+    "\n",
+    "handles = []\n",
+    "labels = []\n",
+    "handles.extend([line3])\n",
+    "labels.extend([line3.get_label()])\n",
+    "\n",
+    "fig.legend(handles=handles, labels=labels, loc='lower center', bbox_to_anchor=(0.55, -0.2), ncol=2, fontsize=10)\n",
+    "\n",
+    "# Adjust spacing between subplots for better layout\n",
+    "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "132f93ec",
+   "metadata": {},
+   "source": [
+    "### Pedigree-DC model for X chromosome admixture"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4deb033a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase-Type density for the Pedigree-DC model (set freq = True for frequency scale)\n",
+    "newbins, density_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = True, X_chr_male = False, N_cores = 5, density = True, freq = True)\n",
+    "# Phase-Type histogram for the Pedigree-DC model\n",
+    "bins, hist_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = True, X_chr_male = False, N_cores = 5, density = False, freq = False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2cc6c08",
+   "metadata": {},
+   "source": [
+    "#### Plot density"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32c72c1a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -399,31 +713,17 @@
     "fig, axes = plt.subplots(1, 1, figsize=(5,4))  # 3x3 grid of subplots\n",
     "ax = axes  \n",
     "# Plot lines with improved color and line style\n",
-    "line1, = ax.step(np.delete(bins, whichbin), (hist_df[~(np.asarray(newbins) == outbin)]), color=colors['DF'], linestyle=line_styles['DF'], linewidth = line_widths['DF'],  label='Dioecious Fine (DF)', zorder = 1)\n",
-    "line2, = ax.step(np.delete(bins, whichbin), (hist_dc[~(np.asarray(newbins) == outbin)]), color=colors['DC'], linestyle=line_styles['DC'], linewidth = line_widths['DC'], label='Dioecious Coarse (DC)', zorder = 1)\n",
-    "line3, = ax.step(np.delete(bins, whichbin), (hist_m[~(np.asarray(newbins) == outbin)]), color=colors['M'], linestyle=line_styles['M'], linewidth = line_widths['M'], label='Monoecious (M)', zorder = 1)\n",
-    "line4, = ax.step(np.delete(bins, whichbin), hist_hp_df[~(np.asarray(newbins) == outbin)], color=colors['HP'], linestyle=line_styles['HP'], linewidth = line_widths['HP'], label='Ped-DF (TP = 2)', zorder = 1)\n",
-    "line5, = ax.step(np.delete(bins, whichbin), hist_hp_df[~(np.asarray(newbins) == outbin)], color=colors['DF'], linestyle=(2, (2, 2)), linewidth = line_widths['HP'], label='Ped-DF (TP = 2)', zorder = 1)\n",
-    "line6, = ax.step(np.delete(bins, whichbin), hist_hp_dc[~(np.asarray(newbins) == outbin)], color=colors['HP_DC'], linestyle=line_styles['HP_DC'], linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)', zorder = 1)\n",
-    "line7, = ax.step(np.delete(bins, whichbin), hist_hp_dc[~(np.asarray(newbins) == outbin)], color=colors['DC'], linestyle=(2, (2, 2)), linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)', zorder = 1)\n",
+    "line6, = ax.plot(np.delete(newbins, whichbin), density_hp_dc[~(np.asarray(newbins) == outbin)], color=colors['HP_DC'], linestyle=line_styles['HP_DC'], linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)', zorder = 1)\n",
+    "line7, = ax.plot(np.delete(newbins, whichbin), density_hp_dc[~(np.asarray(newbins) == outbin)], color=colors['DC'], linestyle=(2, (2, 2)), linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)', zorder = 1)\n",
     "        \n",
     "# Customize x and y labels\n",
-    "ax.set_xlabel('Tract length on the second chromosome', fontsize=10)\n",
+    "ax.set_xlabel('Tract length on the X chromosome', fontsize=10)\n",
     "ax.set_ylabel('Density', fontsize=10)\n",
     "        \n",
     "# Add outlier point to the plot\n",
-    "ax.scatter(outbin, (density_df[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['DF'], s=30, label='Outlier', marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
-    "ax.scatter(outbin, (density_dc[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['DC'], s=30, label='Outlier',marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
-    "ax.scatter(outbin, (density_m[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['M'], s=30, label='Outlier', marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
-    "ax.scatter(outbin, (density_hp_df[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['HP'], s=30, label='Outlier', marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
     "ax.scatter(outbin, (density_hp_dc[np.where(newbins == outbin)[0] - 1]), edgecolor=colors['HP_DC'], s=30, label='Outlier', marker='o', facecolor='white', alpha = 1, zorder = 3)\n",
     "\n",
     "# Add outlier point to the plot\n",
-    "ax.scatter(outbin, density_df[np.where(newbins == outbin)], edgecolor=colors['DF'], s=30, label='Outlier', marker='o', facecolor=colors['DF'], zorder = 4)\n",
-    "ax.scatter(outbin, density_hp_dc[np.where(newbins == outbin)], edgecolor=colors['DC'], s=30, label='Outlier',marker='o', facecolor=colors['DC'], zorder = 4)\n",
-    "ax.scatter(outbin, density_m[np.where(newbins == outbin)], edgecolor=colors['M'], s=30, label='Outlier', marker='o', facecolor=colors['M'], zorder = 4)\n",
-    "ax.scatter(outbin, density_hp_df[np.where(newbins == outbin)], edgecolor=colors['HP'], s=30, label='Outlier', marker='o', facecolor=colors['HP'], zorder = 4)\n",
-    "ax.scatter(outbin, density_hp_df[np.where(newbins == outbin)], edgecolor=colors['HP'], s=15, label='Outlier', marker='o', facecolor=colors['DF'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_dc[np.where(newbins == outbin)], edgecolor=colors['HP_DC'], s=30, label='Outlier', marker='o', facecolor=colors['HP_DC'], zorder = 4)\n",
     "ax.scatter(outbin, density_hp_dc[np.where(newbins == outbin)], edgecolor=colors['HP_DC'], s=15, label='Outlier', marker='o', facecolor=colors['DC'], zorder = 4)\n",
     "\n",
@@ -439,16 +739,64 @@
     "\n",
     "handles = []\n",
     "labels = []\n",
-    "handles.extend([line1, line2, line3, (line4, line5), (line6, line7)])\n",
-    "labels.extend([line1.get_label(), line2.get_label(), line3.get_label(), line4.get_label(), line6.get_label()])\n",
+    "handles.extend([(line6, line7)])\n",
+    "labels.extend([line6.get_label()])\n",
     "\n",
     "fig.legend(handles=handles, labels=labels, loc='lower center', bbox_to_anchor=(0.55, -0.2), ncol=2, fontsize=10)\n",
     "\n",
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d987b152",
+   "metadata": {},
+   "source": [
+    "#### Plot histogram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "594d3132",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
+    "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5,4)) \n",
+    "\n",
+    "# Plot lines with improved color and line style\n",
+    "line6, = ax.step(bins[:-1], hist_hp_dc, color=colors['HP_DC'], linestyle=line_styles['HP_DC'], linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)')\n",
+    "line7, = ax.step(bins[:-1], hist_hp_dc, color=colors['DC'], linestyle=(2, (2, 2)), linewidth = line_widths['HP_DC'], label='Ped-DC (TP = 2)')\n",
+    "        \n",
+    "# Customize x and y labels\n",
+    "ax.set_xlabel('Tract length on the X chromosome', fontsize=10)\n",
+    "ax.set_ylabel('Expected number of tracts per interval', fontsize=10)\n",
+    "        \n",
+    "# Add gridlines\n",
+    "ax.grid(True, linestyle='--', alpha=0.6)\n",
+    "\n",
+    "# Set limits for x-axis and y-axis if necessary\n",
+    "ax.set_xlim(0, which_L+0.1)\n",
+    "\n",
+    "# Customize the ticks\n",
+    "ax.tick_params(axis='both', which='major', labelsize=10)\n",
+    "\n",
+    "handles = []\n",
+    "labels = []\n",
+    "handles.extend([(line6, line7)])\n",
+    "labels.extend([line6.get_label()])\n",
+    "\n",
+    "fig.legend(handles=handles, labels=labels, loc='lower center', bbox_to_anchor=(0.55, -0.2), ncol=2, fontsize=10)\n",
+    "\n",
+    "# Adjust spacing between subplots for better layout\n",
+    "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {

--- a/example/3pops_sexbiased/ASW_tractlength_3pop_sexbiased_fix.py
+++ b/example/3pops_sexbiased/ASW_tractlength_3pop_sexbiased_fix.py
@@ -6,12 +6,6 @@ sys.path.append('.')
 from tracts.driver import run_tracts
 
 script_path = Path(sys.argv[0]).resolve()
-script_directory = script_path.parent
-
-script_path = Path(sys.argv[0]).resolve()
-script_directory = script_path.parent
-
-script_path = "/home/jgonzale/Documents/PhaseType/tracts/example/3pops_sexbiased"
 
 driver_filename = "ASW_tractlength_one_pulse.yaml"
 

--- a/example/3pops_sexbiased/ASW_tractlength_one_pulse.yaml
+++ b/example/3pops_sexbiased/ASW_tractlength_one_pulse.yaml
@@ -14,14 +14,16 @@ output_filename_format: "ASW_test_output_{label}"
 model_filename: ppp.yaml
 start_params: 
   t: 5-8
-  REUR: 0.5
+  REUR: 0.4
   RNAT: 0.2
-  REUR_sex_bias: 0
-  RNAT_sex_bias: 0
+  REUR_sex_bias: 0.1
+  RNAT_sex_bias: 0.1
 repetitions: 1
 seed: 100
 unknown_labels_for_smoothing: ["UNK", "centromere","miscall"] # segments with these labels will be smoother over, that is, will be filled with neighbouring ancestries up to their midpoints.  
 exclude_tracts_below_cM: 2
-npts : 100
+npts : 50
 fix_parameters_from_ancestry_proportions: ['REUR', 'RNAT', 'REUR_sex_bias', 'RNAT_sex_bias']
 time_scaling_factor: 100 #Times will be scaled down by this much when running the optimizer.
+output_directory: ./output_fix/
+

--- a/example/toy_example.ipynb
+++ b/example/toy_example.ipynb
@@ -14,6 +14,7 @@
    "execution_count": null,
    "id": "c33f835d",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Import required libraries\n",
     "import tracts.phase_type_distribution as PhT\n",
@@ -23,8 +24,7 @@
     "from matplotlib.ticker import FormatStrFormatter\n",
     "import matplotlib as mpl\n",
     "mpl.rcParams.update(mpl.rcParamsDefault)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -36,14 +36,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cb8b3bca",
    "metadata": {},
+   "outputs": [],
    "source": [
     "whichpop = 1\n",
     "mig_matrix = np.array([[0, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0, 1]])"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -72,27 +72,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "7cdca656",
    "metadata": {},
+   "outputs": [],
    "source": [
     "X_chr = False # Set to True for admixture on the X chromosome\n",
     "X_chr_male = False # Set to True if admixture is considered on the X chromosome of a male individual (only maternally inherited alleles)."
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "a88d4d00",
    "metadata": {},
+   "outputs": [],
    "source": [
     "which_L = 1.7928357829 # Second chromosome\n",
     "#which_L = 1.96 # For the X chromosome\n",
     "# Set a point grid on the finite chromosome\n",
     "bins = np.linspace(0, which_L+0.1, num = 50)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -108,6 +108,7 @@
    "execution_count": null,
    "id": "af95faed",
    "metadata": {},
+   "outputs": [],
    "source": [
     "prop_of_female_migration = 0.5 # 0.5 for unbiased migration, 1 for only female migrants, 0 for only male migrants.\n",
     "mig_m = 2*mig_matrix*(1-prop_of_female_migration)\n",
@@ -117,8 +118,7 @@
     "\n",
     "rec_f = 1 # Female-specific recombination rate\n",
     "rec_m = 1 # Male-specific recombination rate"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -144,14 +144,14 @@
    "execution_count": null,
    "id": "82b132b7",
    "metadata": {},
+   "outputs": [],
    "source": [
     "PTmodel_mono = PhT.PhTMonoecious(mig_matrix, rho = 0.5*(rec_f+rec_m)) # M object\n",
     "# Density (set freq = True for frequency scale)\n",
     "newbins, density_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
     "# Histogram\n",
-    "hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
-   ],
-   "outputs": []
+    "bins, hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -166,6 +166,7 @@
    "execution_count": null,
    "id": "fa5812c0",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# DF and DC objects\n",
     "PTmodel_DF = PhT.PhTDioecious(mig_f, mig_m, rho_f = rec_f, rho_m = rec_m, sex_model = 'DF', X_chromosome = X_chr, X_chromosome_male = X_chr_male)\n",
@@ -174,17 +175,16 @@
     "newbins, density_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
     "newbins, density_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
     "# Histograms\n",
-    "hist_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)\n",
-    "hist_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
-   ],
-   "outputs": []
+    "bins, hist_df, E = PTmodel_DF.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)\n",
+    "bins, hist_dc, E = PTmodel_DC.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e692c16a",
    "metadata": {},
    "source": [
-    "#### Pedigree-Dioecious models"
+    "#### Hybrid-pedigree refinements"
    ]
   },
   {
@@ -192,6 +192,7 @@
    "execution_count": null,
    "id": "d0b28cbf",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Phase-Type density for the Pedigree-DF model (set freq = True for frequency scale)\n",
     "newbins, density_hp_df = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DF', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = True, freq = True)\n",
@@ -201,8 +202,7 @@
     "bins, hist_hp_df = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DF', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = False, freq = False)\n",
     "# Phase-Type histogram for the Pedigree-DC model\n",
     "bins, hist_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = X_chr, X_chr_male = X_chr_male, N_cores = 5, density = False, freq = False)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -217,6 +217,7 @@
    "execution_count": null,
    "id": "3b527680",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Color palette and line styles\n",
     "colors = {\n",
@@ -244,8 +245,7 @@
     "    'HP':2,\n",
     "    'HP_DC':2\n",
     "}"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -269,6 +269,7 @@
    "execution_count": null,
    "id": "6622fbb7",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -325,8 +326,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -342,6 +342,7 @@
    "execution_count": null,
    "id": "35660016",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -394,8 +395,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -412,6 +412,7 @@
    "execution_count": null,
    "id": "f6289e9b",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -450,8 +451,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -467,6 +467,7 @@
    "execution_count": null,
    "id": "55af0c51",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -504,8 +505,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -521,18 +521,19 @@
    "execution_count": null,
    "id": "27b9ea46",
    "metadata": {},
+   "outputs": [],
    "source": [
     "whichpop = 1\n",
     "mig_matrix = np.array([[0, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0.2, 0],[0, 1]])\n",
     "print(np.shape(mig_matrix)[0]-1) # Number of generations"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "0ad3818e",
    "metadata": {},
+   "outputs": [],
    "source": [
     "prop_of_female_migration = 0.5 # 0.5 for unbiased migration, 1 for only female migrants, 0 for only male migrants.\n",
     "mig_m = 2*mig_matrix*(1-prop_of_female_migration)\n",
@@ -542,8 +543,7 @@
     "\n",
     "rec_f = 1 # Female-specific recombination rate\n",
     "rec_m = 1 # Male-specific recombination rate"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -558,14 +558,14 @@
    "execution_count": null,
    "id": "ae3b297b",
    "metadata": {},
+   "outputs": [],
    "source": [
     "PTmodel_mono = PhT.PhTMonoecious(mig_matrix, rho = 0.5*(rec_f+rec_m)) # M object\n",
     "# Density (set freq = True for frequency scale)\n",
     "newbins, density_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = True, freq = True)\n",
     "# Histogram\n",
-    "hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
-   ],
-   "outputs": []
+    "bins, hist_m, E = PTmodel_mono.tractlength_histogram_windowed(whichpop, bins, L = which_L, density = False, freq = False)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -580,6 +580,7 @@
    "execution_count": null,
    "id": "8a3b8803",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -620,8 +621,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -636,6 +636,7 @@
    "execution_count": null,
    "id": "2ff050fb",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -668,8 +669,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -684,13 +684,13 @@
    "execution_count": null,
    "id": "4deb033a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Phase-Type density for the Pedigree-DC model (set freq = True for frequency scale)\n",
     "newbins, density_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = True, X_chr_male = False, N_cores = 5, density = True, freq = True)\n",
     "# Phase-Type histogram for the Pedigree-DC model\n",
     "bins, hist_hp_dc = HP.hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m, TP = 2, Dioecious_model = 'DC', L = which_L, bingrid = bins, whichpop = whichpop, rr_f = rec_f, rr_m = rec_m, X_chr = True, X_chr_male = False, N_cores = 5, density = False, freq = False)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -705,6 +705,7 @@
    "execution_count": null,
    "id": "32c72c1a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -746,8 +747,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -762,6 +762,7 @@
    "execution_count": null,
    "id": "594d3132",
    "metadata": {},
+   "outputs": [],
    "source": [
     "outbin = np.max(np.asarray(newbins)[np.asarray(newbins) == which_L])\n",
     "whichbin = int(np.where(np.asarray(newbins) == outbin)[0][0])\n",
@@ -795,8 +796,7 @@
     "# Adjust spacing between subplots for better layout\n",
     "plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
     "plt.show()"
-   ],
-   "outputs": []
+   ]
   }
  ],
  "metadata": {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,9 +62,9 @@ def verify_similar_ptd_models(ptd_first: PhaseTypeDistribution, ptd_second: Phas
                                                                              density=True, freq=True)
     newbins, counts_second_freq, E = ptd_second.tractlength_histogram_windowed(population_number=0, bins=bins, L=Ls[1],
                                                                                density=True, freq=True)
-    counts_first_hist, E = ptd_first.tractlength_histogram_windowed(population_number=0, bins=bins, L=Ls[1],
+    outbins, counts_first_hist, E = ptd_first.tractlength_histogram_windowed(population_number=0, bins=bins, L=Ls[1],
                                                                     density=False)
-    counts_second_hist, E = ptd_second.tractlength_histogram_windowed(population_number=0, bins=bins, L=Ls[1],
+    outbins, counts_second_hist, E = ptd_second.tractlength_histogram_windowed(population_number=0, bins=bins, L=Ls[1],
                                                                       density=False)
 
     # Densities must be close
@@ -330,7 +330,7 @@ class ModelComparison:
 
     def compare_models(self, bins, L, population_number):
         PTD_hist_tuple = self.PTD.tractlength_histogram_windowed(population_number, bins, L)
-        PTD_hist = PTD_hist_tuple[0]
+        PTD_hist = PTD_hist_tuple[1]
         demo_hist = self.demo.expectperbin([L], population_number, bins)[:-1]
         print(f'\nTractlength histogram from PTD: \n{PTD_hist}')
         print(f'\nTractlength histogram from tracts: \n{numpy.array(demo_hist)}')
@@ -338,12 +338,14 @@ class ModelComparison:
 
     def compare_models_2(self, input_bins, L, population_number):
         # TODO: Decide if this should be moved to examples
-        PTD_hist = self.PTD.tractlength_histogram_windowed(population_number, input_bins, L)
+        PTD_hist_tuple = self.PTD.tractlength_histogram_windowed(population_number, bins, L)
+        PTD_hist = PTD_hist_tuple[1]
         demo_hist = self.demo.expectperbin([L], population_number, input_bins)
         plot_histogram_model_comparison(PTD_hist, demo_hist, L)
 
     def compare_models_3(self, bins, L, population_number):
-        PTD_hist = self.PTD.tractlength_histogram_windowed(population_number, bins, L)
+        PTD_hist_tuple = self.PTD.tractlength_histogram_windowed(population_number, bins, L)
+        PTD_hist = PTD_hist_tuple[1]
         # TODO: Check that the correct function name has been guessed correctly
         # PTD_CDF = PTD.tractlength_CDF_windowed(population_number, bins, L)
         PTD_CDF = self.PTD.tractlength_histogram_windowed(population_number, bins, L)
@@ -353,7 +355,7 @@ class ModelComparison:
     def compare_models_4(self, bins, L, population_number):
         # TODO: Move to examples
         PTD_hist_tuple = self.PTD.tractlength_histogram_windowed(population_number, bins, L)
-        PTD_hist = PTD_hist_tuple[0]
+        PTD_hist = PTD_hist_tuple[1]
         demo_hist = per_bin_noscale(self.demo, bins, L, population_number)[:-1]
         # demo_hist2 = per_bin_noscale(self.demo, bins, L, population_number)
         # TODO: demo_hist and demo_hist2 can be compared with numpy.allclose(demo_hist, demo_hist2)
@@ -371,7 +373,7 @@ class ModelComparison:
                                                        self.PTD.alpha_list[population_number]) for L in Ls])
 
         ratios = numpy.array([numpy.sum(self.demo.expectperbin([L], population_number, bins)) / numpy.sum(
-            self.PTD.tractlength_histogram_windowed(population_number, bins, L)) for L in Ls])
+            self.PTD.tractlength_histogram_windowed(population_number, bins, L)[1]) for L in Ls])
         print(f'\nRatios of expectperbin (tracts) to histogram (PhaseType): \n{ratios}')
         print(f'\nRatios divided by Z: \n{numpy.divide(ratios, Z)}')
         weird_factors = self.weird_factors(Ls, population_number)
@@ -446,5 +448,5 @@ def expectperbin_ratios(migration_matrix, input_bins, Ls, population_number):
     demo = DemographicModel(migration_matrix)
     PTD = PhTMonoecious(migration_matrix)
     demo_hist = lambda L: demo.expectperbin([L], population_number, input_bins)
-    PTD_hist = lambda L: PTD.tractlength_histogram_windowed(population_number, input_bins, L)
+    PTD_hist = lambda L: PTD.tractlength_histogram_windowed(population_number, input_bins, L)[1]
     return numpy.array([numpy.sum(demo_hist(L)) / numpy.sum(PTD_hist(L)) for L in Ls])

--- a/tracts/phase_type_distribution.py
+++ b/tracts/phase_type_distribution.py
@@ -598,7 +598,7 @@ class PhTMonoecious(PhaseTypeDistribution):
         -------
 
         npt.ArrayLike
-            If density is True, the corrected bins grid as described in Notes. Else, nothing is returned here.
+            If density is True, the corrected bins grid as described in Notes. Else, the bins introduced as input.
         npt.ArrayLike
             If density is True, the PhT density evaluated on the corrected bins grid. Returned on the frequency scale if freq = True.
             If density is False, the histogram values on the intervals defined by bins.
@@ -631,7 +631,7 @@ class PhTMonoecious(PhaseTypeDistribution):
             raise Exception('CDF not positive and real : ', normalized_CDF)
             # = self.normalization_factor(L, S, S0_inv, alpha) # Add test to compare Z and Zint
         scale = 2 * self.t0_proportions[population_number] * L / ETL
-        return np.real(np.diff(normalized_CDF) * scale), ETL
+        return bins, np.real(np.diff(normalized_CDF) * scale), ETL
 
     def tract_length_histogram_multi_windowed(self, population_number: int, bins: npt.ArrayLike,
                                               chrom_lengths: npt.ArrayLike) -> npt.ArrayLike:
@@ -644,7 +644,7 @@ class PhTMonoecious(PhaseTypeDistribution):
         for bin_number, bin_val in enumerate(bins):
             exp_Sx_per_bin[bin_number] = scipy.linalg.expm(bin_val * S)
         for L in chrom_lengths:
-            new_histogram, ETL = self.tractlength_histogram_windowed(population_number, bins, L, exp_Sx_per_bin,
+            bins, new_histogram, ETL = self.tractlength_histogram_windowed(population_number, bins, L, exp_Sx_per_bin,
                                                                        exp_Sx_per_bin_f, exp_Sx_per_bin_m)
             histogram += new_histogram
         return histogram
@@ -940,7 +940,9 @@ class PhTDioecious(PhaseTypeDistribution):
             migration_matrix_m[0, :] = 0
             migration_matrix_f[0, :] = 0
 
-        if np.sum(np.abs(migration_matrix_f[-1, :])) != 1 or np.sum(np.abs(migration_matrix_m[-1, :])) != 1:
+        if not np.isclose(np.sum(np.abs(migration_matrix_f[-1, :])), 1, atol=1e-3) or not np.isclose(np.sum(np.abs(migration_matrix_m[-1, :])), 1, atol = 1e-3):
+            print('migration_matrix_f : \n', migration_matrix_f)
+            print('migration_matrix_m : \n', migration_matrix_m)
             raise Exception(
                 'Contributions from source populations at the last generation in the past must sum up to 1.')
 
@@ -1184,7 +1186,7 @@ class PhTDioecious(PhaseTypeDistribution):
         -------
 
         npt.ArrayLike
-            If density is True, the corrected bins grid as described in Notes. Else, nothing is returned here.
+            If density is True, the corrected bins grid as described in Notes. Else, the bins provided as input.
         npt.ArrayLike
             If density is True, the PhT density evaluated on the corrected bins grid. Returned on the frequency scale if freq = True.
             If density is False, the histogram values on the intervals defined by bins.
@@ -1246,9 +1248,7 @@ class PhTDioecious(PhaseTypeDistribution):
                 
         elif not xi_f and not xi_m:
             raise Exception('The state space for population',population_number, ' is empty. No tracts from population ', population_number, ' allowed.')
-        
-            
-        
+                
         
         if return_only == 0 or return_only is None:
             S_m = self.transition_matrices_m[population_number]
@@ -1280,41 +1280,63 @@ class PhTDioecious(PhaseTypeDistribution):
                                                                            exp_Sx_per_bin=exp_Sx_per_bin_f, s1=1,
                                                                            pop_number=population_number,
                                                                            hybrid_pedigree = hybrid_ped)
+        
+        # The return_only parameter is used to select only maternally or paternally inherited tracts
+        # Besides controlling the case of allosomal admixture on male individuals, it is used to return
+        # distributions corresponding to connected components in the hybrid pedigree model, that need
+        # to be combined a posteriori: connected components corresponding to maternally (resp. paternally) 
+        # -inherited alleles are first combined into one maternally (resp. paternally) -inherited distribution.
+        # Then, the resulting pair of Phase Type mixtures is combined at the end. See hybrid_pedigree.py for details.
+
+        # Return PhT distribution as a density function, at the frequency or density scale
         if density:
+            # For autosomes or X chromosome in females, both haploids copies are combined.
             if return_only is None and not self.X_chr_male:
                 scale_m = self.t0_proportions_m[population_number] * L / ETL_m  if freq else 0.5
                 scale_f = self.t0_proportions_f[population_number] * L / ETL_f  if freq else 0.5
                 return newbins, scale_m * density_per_bin_f + scale_f * density_per_bin_m, 0.5 * (ETL_m + ETL_f)
-            if return_only == 0 and not self.X_chr_male:
+            # If return_only == 0, only paternally inherited tracts are considered.
+            elif return_only == 0 and not self.X_chr_male:
                 scale_m = self.t0_proportions_m[population_number] * L / ETL_m if freq else 1
                 return newbins, scale_m * density_per_bin_m, ETL_m
-            scale_f = self.t0_proportions_f[population_number] * L / ETL_f if freq else 1
-            return newbins, scale_f * density_per_bin_f, ETL_f
+            # If return_only == 1 or X_chr_male is True (i.e. X chromosome in male individuals), only maternally inherited tracts are considered.
+            else:
+                scale_f = self.t0_proportions_f[population_number] * L / ETL_f if freq else 1
+                return newbins, scale_f * density_per_bin_f, ETL_f
+        
+        # If not density, PhT distribution is returned as a histogram.
+        
+        # For autosomes or X chromosome in females, both haploids copies are combined.
         if return_only is None and not self.X_chr_male:
             normalized_CDF = 0.5 * (normalized_CDF_f + normalized_CDF_m)
             scale_m = self.t0_proportions_m[population_number] * L / ETL_m
             scale_f = self.t0_proportions_f[population_number] * L / ETL_f
             E = (ETL_f + ETL_m) / 2
+        # If return_only == 0, only paternally inherited tracts are considered.
         elif return_only == 0 and not self.X_chr_male:
             normalized_CDF = normalized_CDF_m
             normalized_CDF_f = np.zeros(len(normalized_CDF_m))
             scale_f = 0
             scale_m = self.t0_proportions_m[population_number] * L / ETL_m
             E = ETL_m
+        # If return_only == 1 or X_chr_male is True (i.e. X chromosome in male individuals), only maternally inherited tracts are considered.
         else:
             normalized_CDF = normalized_CDF_f
             normalized_CDF_m = np.zeros(len(normalized_CDF_f))
             scale_m = 0
             scale_f = self.t0_proportions_f[population_number] * L / ETL_f
             E = ETL_f
+        
+
         if not np.all(np.isreal(normalized_CDF_m)) or np.any(normalized_CDF_m < -1e-3):
             raise Exception('type-m CDF is not positive and real : ', normalized_CDF_m)
         if not np.all(np.isreal(normalized_CDF_f)) or np.any(normalized_CDF_f < -1e-3):
             raise Exception('type-f CDF is not positive and real : ', normalized_CDF_f)
-        if not hybrid_ped:
-            return np.real(np.diff(normalized_CDF_m) * scale_m + np.diff(normalized_CDF_f) * scale_f), E
-
-        return bins, normalized_CDF, E
+        
+        if not hybrid_ped: # In the Dioecious Model, maternally and paternally -inherited distributions are combined and returned now.
+            return bins, np.real(np.diff(normalized_CDF_m) * scale_m + np.diff(normalized_CDF_f) * scale_f), E
+        else: # In the hybrid pedigree model, connected components are combined later.
+            return bins, normalized_CDF, E
 
     def tract_length_histogram_multi_windowed(self, population_number: int, bins: npt.ArrayLike,
                                               chrom_lengths: npt.ArrayLike) -> npt.ArrayLike:
@@ -1328,8 +1350,8 @@ class PhTDioecious(PhaseTypeDistribution):
             exp_Sx_per_bin_f[bin_number] = scipy.linalg.expm(bin_val * S_f)
             exp_Sx_per_bin_m[bin_number] = scipy.linalg.expm(bin_val * S_m)
         for L in chrom_lengths:
-            new_histogram, E = self.tractlength_histogram_windowed(population_number = population_number, bins = bins, L= L,
-                                                                       exp_Sx_per_bin_f = exp_Sx_per_bin_f, exp_Sx_per_bin_m =exp_Sx_per_bin_m)
+            bins, new_histogram, E = self.tractlength_histogram_windowed(population_number = population_number, bins = bins, L = L,
+                                                                       exp_Sx_per_bin_f = exp_Sx_per_bin_f, exp_Sx_per_bin_m = exp_Sx_per_bin_m)
         
 
 

--- a/tracts/population.py
+++ b/tracts/population.py
@@ -405,7 +405,7 @@ class Population:
             if allosome not in indiv.allosomes:
                 raise logger.warning(f"Data for chromosome {allosome} does not exist on individual {indiv.name}.")
             if is_male and  len(indiv.allosomes[allosome]) == 2:
-                logger.warning(f"Individual {indiv.name} is listed as male but has two X chromsosomes. Selecting first of the two")
+                logger.warning(f"Individual {indiv.name} is listed as male but has two X chromosomes. Selecting first of the two.")
                 assert indiv.allosomes[allosome][0].is_equal(indiv.allosomes[allosome][1]), f"Male Individual {indiv} has two different X chromosomes." 
                 indiv.allosomes[allosome] = [indiv.allosomes[allosome][0]]
             is_male = (len(indiv.allosomes[allosome]) == 1) ## Males are now either individuals labeled as males, or individuals who have a single X chromsome in data file. 


### PR DESCRIPTION
This commit modifies the output of tractlength_histogram_windowed to have always a three-tuple containing bins, the density/frequency/counts array, the tractlength expectation.

Also adapt the corresponding functions in the toy-example notebook.