### PR TITLE
Allow for all autosomal and allosomal models

### DIFF
--- a/example/3pops_sexbiased/ASW/ASW_three_pulses.yaml
+++ b/example/3pops_sexbiased/ASW/ASW_three_pulses.yaml
@@ -35,4 +35,5 @@ npts : 50
 fix_parameters_from_ancestry_proportions: ['REUR2', 'RAFR', 'REUR2_sex_bias', 'RAFR_sex_bias']
 time_scaling_factor: 100 #Times will be scaled down by this much when running the optimizer.
 output_directory: ./output_fix/
-M_for_autosomes: True
+ad_model_autosomes: DC
+ad_model_allosomes: H-DC

--- a/tracts/core.py
+++ b/tracts/core.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy.optimize
 from matplotlib import pylab
 
+import tracts.hybrid_pedigree as HP
 from tracts.phase_type_distribution import PhTMonoecious, PhTDioecious
 from tracts.demography.demographic_model import DemographicModel
 from tracts.demography.composite_demographic_model import CompositeDemographicModel
@@ -172,7 +173,7 @@ def optimize_cob(p0, bins, Ls, data, nsamp, model_func, outofbounds_fun=None, cu
 
 def optimize_cob_sex_biased(p0, population: Population, model_func, outofbounds_fun=None, cutoff=0, verbose=0, flush_delay=1,
                  epsilon=1e-3, gtol=1e-5, p_dict=None, exclude_tracts_below_cM=0, maxiter=None, full_output=True, func_args=None, fixed_params=None,
-                 ll_scale=1, reset_counter=True, modelling_method=PhTDioecious, D_model='DC', npts=50, M_for_autosomes=False) -> tuple[np.ndarray, float]:
+                 ll_scale=1, reset_counter=True, modelling_method=PhTDioecious, ad_model_autosomes='DC', ad_model_allosomes='DC', npts=50) -> tuple[np.ndarray, float]:
     if reset_counter:
         global _counter
         _counter = 0
@@ -222,13 +223,27 @@ def optimize_cob_sex_biased(p0, population: Population, model_func, outofbounds_
         matrices = model_func(parameters)
         [male_matrix, female_matrix] = [matrix for matrix in matrices.values()]
         
-        if M_for_autosomes: # For computational efficiency, use monoecious model for autosomes
+        # Model for autosomes
+        if ad_model_autosomes == 'M':
             result_autosomes = PhTMonoecious(0.5*(female_matrix+male_matrix), rho=1).loglik(autosome_bins, population.Ls, [mat for mat in autosome_data_mapped], len(population.indivs))
+        elif ad_model_autosomes == 'H-DC':
+            result_autosomes=HP.HP_loglik(female_matrix, male_matrix, rr_f=1, rr_m=1, TP = 2, Dioecious_model = 'DC', X_chr = False, X_chr_male = False, N_cores = 5, bins=autosome_bins, Ls=population.Ls, data=[mat for mat in autosome_data_mapped], num_samples=len(population.indivs), cutoff=0)
+        elif ad_model_autosomes == 'H-DF':
+            result_autosomes=HP.HP_loglik(female_matrix, male_matrix, rr_f=1, rr_m=1, TP = 2, Dioecious_model = 'DF', X_chr = False, X_chr_male = False, N_cores = 5, bins=autosome_bins, Ls=population.Ls, data=[mat for mat in autosome_data_mapped], num_samples=len(population.indivs), cutoff=0)
         else:
-            result_autosomes = PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=D_model).loglik(autosome_bins, population.Ls, [mat for mat in autosome_data_mapped], len(population.indivs))
+            result_autosomes = PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=ad_model_autosomes).loglik(autosome_bins, population.Ls, [mat for mat in autosome_data_mapped], len(population.indivs))
         
-        result_X_females = PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=D_model, X_chromosome=True).loglik(allosome_bins, [allosome_length], [mat for mat in female_data_mapped], num_females)
-        result_X_males = PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=D_model, X_chromosome=True, X_chromosome_male=True).loglik(allosome_bins, [allosome_length], [mat for mat in male_data_mapped], num_males)
+        # Model for allosomes
+        if ad_model_allosomes == 'H-DC':
+            result_X_females = HP.HP_loglik(female_matrix, male_matrix, rr_f=1, rr_m=1, TP = 2, Dioecious_model = 'DC', X_chr = True, X_chr_male = False, N_cores = 5, bins=allosome_bins, Ls=[allosome_length], data=[mat for mat in female_data_mapped], num_samples=num_females, cutoff=0)
+            result_X_males = HP.HP_loglik(female_matrix, male_matrix, rr_f=1, rr_m=1, TP = 2, Dioecious_model = 'DC', X_chr = True, X_chr_male = True, N_cores = 5, bins=allosome_bins, Ls=[allosome_length], data=[mat for mat in male_data_mapped], num_samples=num_males, cutoff=0)
+        elif ad_model_allosomes == 'H-DF':
+            result_X_females = HP.HP_loglik(female_matrix, male_matrix, rr_f=1, rr_m=1, TP = 2, Dioecious_model = 'DF', X_chr = True, X_chr_male = False, N_cores = 5, bins=allosome_bins, Ls=[allosome_length], data=[mat for mat in female_data_mapped], num_samples=num_females, cutoff=0)
+            result_X_males = HP.HP_loglik(female_matrix, male_matrix, rr_f=1, rr_m=1, TP = 2, Dioecious_model = 'DF', X_chr = True, X_chr_male = True, N_cores = 5, bins=allosome_bins, Ls=[allosome_length],data=[mat for mat in male_data_mapped], num_samples=num_males, cutoff=0)   
+        else:
+            result_X_females = PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=ad_model_allosomes, X_chromosome=True).loglik(allosome_bins, [allosome_length], [mat for mat in female_data_mapped], num_females)
+            result_X_males = PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=ad_model_allosomes, X_chromosome=True, X_chromosome_male=True).loglik(allosome_bins, [allosome_length], [mat for mat in male_data_mapped], num_males)
+        
         result = (result_autosomes + result_X_females + result_X_males)
         flush_result(result_autosomes, 'Autosomes')
         flush_result(result_X_females, 'Female allosomes')
@@ -236,14 +251,9 @@ def optimize_cob_sex_biased(p0, population: Population, model_func, outofbounds_
         
         return -result
     
-    if M_for_autosomes:
-        print('\n--------------------------------------------------------------------------------------------------')
-        print('Admixture is modelled with the Monoecious model for autosomes and with the', D_model,'model for allosomes.')
-        print('--------------------------------------------------------------------------------------------------')
-    else:
-        print('\n--------------------------------------------------------------------')
-        print('Admixture is modelled with the', D_model, 'model for autosomes and allosomes.')
-        print('--------------------------------------------------------------------')
+    print('\n--------------------------------------------------------------------------------------------------')
+    print('Admixture is modelled with the',ad_model_autosomes,'model for autosomes and with the', ad_model_allosomes,'model for allosomes.')
+    print('--------------------------------------------------------------------------------------------------')
     print('Optimizing model likelihood.\n---------------------------\nIter.\t Log-likelihood\t Model parameters \t\t Transmission\n---------------------------------------------------------------------\n')
            
     outputs = scipy.optimize.fmin_cobyla(

--- a/tracts/driver.py
+++ b/tracts/driver.py
@@ -12,6 +12,7 @@ import warnings
 
 from tracts.population import Population
 from tracts.core import optimize_cob, optimize_cob_sex_biased
+import tracts.hybrid_pedigree as HP
 from tracts.phase_type_distribution import PhTMonoecious, PhTDioecious
 from tracts.demography.parametrized_demography import ParametrizedDemography
 from tracts.demography.parametrized_demography_sex_biased import ParametrizedDemographySexBiased
@@ -45,11 +46,30 @@ def locate_file_path(filename: str, script_dir: str | Path | None, absolute_driv
             return Path(pathname) / filename
     return None
 
-def run_tracts(driver_filename, script_dir=None, D_model = 'DC'):
+def run_tracts(driver_filename, script_dir=None):
 
     driver_path = locate_file_path(filename=driver_filename, script_dir=script_dir)
     driver_spec = load_driver_file(driver_path)
     
+    # Set autosomal and allosomal models for admixture
+    if 'ad_model_autosomes' in driver_spec:
+        ad_model_autosomes = driver_spec['ad_model_autosomes']
+        if not ad_model_autosomes in ['DC','DF','M','H-DC','H-DF']:
+            print('The model for autosomal admixture must be either DC (for Dioecious-Coarse), DF (for Dioecious-Fine), M (for Monoecious), H-DC or H-DF (for the hybrid pedigree refinements of DC and DF, resp.). Setting ad_model_autosomes = DC by default.')
+            ad_model_autosomes = 'DC'
+    else:
+        print('Model for autosomal admixture not specified. Setting DC by default.')
+        ad_model_autosomes = 'DC'
+    
+    if 'ad_model_allosomes' in driver_spec:
+        ad_model_allosomes = driver_spec['ad_model_allosomes']
+        if not ad_model_allosomes in ['DC','DF','H-DC','H-DF']:
+            print('The model for allosomal admixture must be either DC (for Dioecious-Coarse), DF (for Dioecious-Fine), H-DC or H-DF (for the hybrid pedigree refinements of DC and DF, resp.). Setting ad_model_allosomes = DC by default.')
+            ad_model_allosomes = 'DC'
+    else:
+        print('Model for allosomal admixture not specified. Setting DC by default.')
+        ad_model_allosomes = 'DC'
+
     if 'exclude_tracts_below_cM' in driver_spec:
         exclude_tracts_below_cM = driver_spec['exclude_tracts_below_cM']
     else:
@@ -66,7 +86,7 @@ def run_tracts(driver_filename, script_dir=None, D_model = 'DC'):
     allosome_labels = driver_spec['samples']['allosomes'] if 'allosomes' in driver_spec['samples'] else []
     allosome_label = allosome_labels[0] if len(allosome_labels) > 0 else None
 
-    # load the population
+    # Load the population
     
     pop = load_population(driver_path, driver_spec, script_dir, allosome_labels = allosome_labels) 
     pop.unknown_labels = driver_spec['unknown_labels_for_smoothing'] if 'unknown_labels_for_smoothing' in driver_spec else [] 
@@ -126,7 +146,7 @@ def run_tracts(driver_filename, script_dir=None, D_model = 'DC'):
                                                         max_iter=max_iter,
                                                         exclude_tracts_below_cM=exclude_tracts_below_cM,
                                                         modelling_method=PhTDioecious if allosome_label else PhTMonoecious,
-                                                        D_model = D_model, npts=npts, M_for_autosomes=driver_spec.get('M_for_autosomes', False))
+                                                        ad_model_autosomes = ad_model_autosomes, ad_model_allosomes=ad_model_allosomes, npts=npts)
     formatted_likelihoods = [float(x) for x in likelihoods]
     print(f"Likelihoods found: {formatted_likelihoods}")
     optimal_params = min(zip(params_found, likelihoods), key=lambda x: x[1])[0]
@@ -137,7 +157,7 @@ def run_tracts(driver_filename, script_dir=None, D_model = 'DC'):
         print([f"{float(p):.2g}" for p in model.fixed_proportions_handler.compute_dependent_params(model, optimal_params)])
     if 'output_filename_format' in driver_spec:
         if allosome_label:
-            output_simulation_data_sex_biased(pop, optimal_params, model, driver_spec, D_model=D_model)
+            output_simulation_data_sex_biased(pop, optimal_params, model, driver_spec, ad_model_autosomes=ad_model_autosomes, ad_model_allosomes=ad_model_allosomes)
         else:
             output_simulation_data(pop, optimal_params, model, driver_spec)
 
@@ -277,7 +297,7 @@ def randomize(arr, a, b):
 
 def run_model_multi_init(model_func: Callable, bound_func: Callable, population: Population, population_labels: list[str], 
                           start_params_list: list[numpy.ndarray], population_dict : dict, max_iter: int=None, exclude_tracts_below_cM: int = 0, 
-                          modelling_method: type = PhTMonoecious, D_model = 'DC', npts: int = 50, M_for_autosomes: bool = False) -> tuple[list[numpy.ndarray], list[float]]:
+                          modelling_method: type = PhTMonoecious, ad_model_autosomes = 'DC', ad_model_allosomes = 'DC', npts: int = 50) -> tuple[list[numpy.ndarray], list[float]]:
     """
     Runs the model multiple times with different initial parameters.
 
@@ -315,16 +335,16 @@ def run_model_multi_init(model_func: Callable, bound_func: Callable, population:
                                                    population_dict,
                                                    max_iter=max_iter,
                                                    exclude_tracts_below_cM=exclude_tracts_below_cM,
-                                                   modelling_method=modelling_method, D_model=D_model, npts=npts, M_for_autosomes=M_for_autosomes)
+                                                   modelling_method=modelling_method, ad_model_autosomes=ad_model_autosomes,ad_model_allosomes=ad_model_allosomes, npts=npts)
         optimal_params.append(params_found)
         likelihoods.append(likelihood_found)
     return optimal_params, likelihoods
 
 
 def run_model(model_func, bound_func, population: Population, population_labels, startparams, population_dict, max_iter=None, exclude_tracts_below_cM=0,
-              modelling_method=PhTMonoecious, D_model='DC', npts=0, M_for_autosomes=False):
+              modelling_method=PhTMonoecious, ad_model_autosomes='DC', ad_model_allosomes='DC', npts=0):
     if modelling_method == PhTDioecious:
-        return run_model_sex_biased(model_func,bound_func, population, population_labels, startparams, population_dict, max_iter, exclude_tracts_below_cM, D_model=D_model, npts=npts, M_for_autosomes=M_for_autosomes)
+        return run_model_sex_biased(model_func,bound_func, population, population_labels, startparams, population_dict, max_iter, exclude_tracts_below_cM, ad_model_autosomes=ad_model_autosomes, ad_model_allosomes=ad_model_allosomes, npts=npts)
     Ls = population.Ls
     nind = population.nind
     bins, data = population.get_global_tractlengths(npts=npts, exclude_tracts_below_cM=exclude_tracts_below_cM)
@@ -336,9 +356,9 @@ def run_model(model_func, bound_func, population: Population, population_labels,
     optlik = optmod.loglik(bins, Ls, data, nind)
     return xopt, optlik
 
-def run_model_sex_biased(model_func, bound_func, population: Population, population_labels, startparams, population_dict, max_iter=None, exclude_tracts_below_cM=0, D_model='DC', npts=0, M_for_autosomes=False):
+def run_model_sex_biased(model_func, bound_func, population: Population, population_labels, startparams, population_dict, max_iter=None, exclude_tracts_below_cM=0, ad_model_autosomes='DC',ad_model_allosomes='DC',npts=0):
   
-    optimal_params, optimal_likelihood = optimize_cob_sex_biased(startparams, population, model_func, bound_func, p_dict = population_dict, exclude_tracts_below_cM=exclude_tracts_below_cM, maxiter=max_iter, epsilon=1e-2,verbose=1, D_model=D_model, npts=npts, M_for_autosomes=M_for_autosomes)
+    optimal_params, optimal_likelihood = optimize_cob_sex_biased(startparams, population, model_func, bound_func, p_dict = population_dict, exclude_tracts_below_cM=exclude_tracts_below_cM, maxiter=max_iter, epsilon=1e-2,verbose=1, ad_model_autosomes=ad_model_autosomes, ad_model_allosomes=ad_model_allosomes, npts=npts)
     return optimal_params, optimal_likelihood
 
 def output_simulation_data(sample_population, optimal_params, model: ParametrizedDemography, driver_spec):
@@ -417,7 +437,7 @@ def output_simulation_data(sample_population, optimal_params, model: Parametrize
         
 
 def output_simulation_data_sex_biased(sample_population: Population, optimal_params, 
-                                      model: ParametrizedDemographySexBiased, driver_spec, D_model='DC'):
+                                      model: ParametrizedDemographySexBiased, driver_spec, ad_model_autosomes='DC', ad_model_allosomes='DC'):
     """
     Creates output graphs to compare data and the theoretical tract length distribution inferred by the model.
     """
@@ -455,9 +475,24 @@ def output_simulation_data_sex_biased(sample_population: Population, optimal_par
     num_males = sample_population.num_males
     num_females = sample_population.num_females
 
-    autosome_predicted={pop:PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=D_model).tract_length_histogram_multi_windowed(pop_num, autosome_bins, Ls) for pop, pop_num in model.population_indices.items()}
-    female_predicted = {pop: PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=D_model, X_chromosome=True).tract_length_histogram_multi_windowed(pop_num, allosome_bins, [allosome_length]) for pop, pop_num in model.population_indices.items()}
-    male_predicted = {pop: PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=D_model, X_chromosome=True, X_chromosome_male=True).tract_length_histogram_multi_windowed(pop_num, allosome_bins, [allosome_length]) for pop, pop_num in model.population_indices.items()}
+    if ad_model_autosomes in ['DC','DF']:
+        autosome_predicted={pop:PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=ad_model_autosomes).tract_length_histogram_multi_windowed(pop_num, autosome_bins, Ls) for pop, pop_num in model.population_indices.items()}
+    elif ad_model_autosomes == 'M':
+        autosome_predicted={pop:PhTMonoecious(0.5*(female_matrix+male_matrix), rho=1).tract_length_histogram_multi_windowed(pop_num, autosome_bins, Ls) for pop, pop_num in model.population_indices.items()}
+    elif ad_model_autosomes == 'H-DC':
+        autosome_predicted={pop:HP.HP_tract_length_histogram_multi_windowed(female_matrix, male_matrix, TP=2, D_model='DC', rr_f=1, rr_m=1, X_chr=False, X_chr_male=False, N_cores=5, population_number= pop_num, bins=autosome_bins, chrom_lengths=Ls) for pop, pop_num in model.population_indices.items()}
+    else:
+        autosome_predicted={pop:HP.HP_tract_length_histogram_multi_windowed(female_matrix, male_matrix, TP=2, D_model='DF', rr_f=1, rr_m=1, X_chr=False, X_chr_male=False, N_cores=5, population_number= pop_num, bins=autosome_bins, chrom_lengths=Ls) for pop, pop_num in model.population_indices.items()}
+    
+    if ad_model_allosomes in ['DC','DF']:
+        female_predicted = {pop: PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=ad_model_allosomes, X_chromosome=True).tract_length_histogram_multi_windowed(pop_num, allosome_bins, [allosome_length]) for pop, pop_num in model.population_indices.items()}
+        male_predicted = {pop: PhTDioecious(female_matrix, male_matrix, rho_f=1, rho_m=1, sex_model=ad_model_allosomes, X_chromosome=True, X_chromosome_male=True).tract_length_histogram_multi_windowed(pop_num, allosome_bins, [allosome_length]) for pop, pop_num in model.population_indices.items()}
+    elif ad_model_allosomes == 'H-DC':
+        female_predicted = {pop:HP.HP_tract_length_histogram_multi_windowed(female_matrix, male_matrix, TP=2, D_model='DC', rr_f=1, rr_m=1, X_chr=True, X_chr_male=False, N_cores=5, population_number= pop_num, bins=allosome_bins, chrom_lengths=[allosome_length]) for pop, pop_num in model.population_indices.items()}
+        male_predicted = {pop:HP.HP_tract_length_histogram_multi_windowed(female_matrix, male_matrix, TP=2, D_model='DC', rr_f=1, rr_m=1, X_chr=True, X_chr_male=True, N_cores=5, population_number= pop_num, bins=allosome_bins, chrom_lengths=[allosome_length]) for pop, pop_num in model.population_indices.items()}
+    else:
+        female_predicted = {pop:HP.HP_tract_length_histogram_multi_windowed(female_matrix, male_matrix, TP=2, D_model='DF', rr_f=1, rr_m=1, X_chr=True, X_chr_male=False, N_cores=5, population_number= pop_num, bins=allosome_bins, chrom_lengths=[allosome_length]) for pop, pop_num in model.population_indices.items()}
+        male_predicted = {pop:HP.HP_tract_length_histogram_multi_windowed(female_matrix, male_matrix, TP=2, D_model='DF', rr_f=1, rr_m=1, X_chr=True, X_chr_male=True, N_cores=5, population_number= pop_num, bins=allosome_bins, chrom_lengths=[allosome_length]) for pop, pop_num in model.population_indices.items()}
     
     # Save results
     
@@ -656,8 +691,6 @@ def output_simulation_data_sex_biased(sample_population: Population, optimal_par
         #allosome_predicted_ancestry[pop] = male_sum + female_sum
         #autosome_predicted_ancestry[pop] = sum(mid * count for mid, count in zip(bin_mids, [num_tracts/(num_males+num_females) for num_tracts in autosome_predicted[pop]]))
         #autosome_data_ancestry[pop] = sum(mid * count for mid, count in zip(bin_mids, [num_tracts/(num_males+num_females) for num_tracts in autosome_data[pop]]))
-
-  
 
         plt.tight_layout(rect=[0, 0.03, 1, 0.95])
         plt.savefig(output_dir + output_filename_format.format(label=f"{pop}_tract_histograms.png"))

--- a/tracts/hybrid_pedigree.py
+++ b/tracts/hybrid_pedigree.py
@@ -13,15 +13,13 @@ import warnings
 from functools import partial
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from joblib import Parallel, delayed
 from scipy import integrate
+from scipy.special import gammaln
 
 from tracts.phase_type_distribution import PhTDioecious
-
-
-warnings.filterwarnings("ignore")
-
 
 def get_pedigree(T):
     n_ind = 2 ** T - 1
@@ -207,7 +205,7 @@ def density_hybrid_pedigree(which_migration, migration_list, T_PED, which_pop, D
 
 def hybrid_pedigree_distribution(mig_matrix_f, mig_matrix_m, L, bingrid, whichpop, TP=2, Dioecious_model='DC',
                                  rr_f=1, rr_m=1, X_chr=False, X_chr_male=False, N_cores=1,
-                                 density=True, freq=False):
+                                 density=True, freq=False, print_progress = True):
     
     """
     This function computes the tract length distribution as a Phase-Type density or histogram on a finite 
@@ -251,6 +249,8 @@ def hybrid_pedigree_distribution(mig_matrix_f, mig_matrix_m, L, bingrid, whichpo
     freq : bool, default False,
         If density is True, whether to return density on the frequency scale. If density is False, this 
         parameter is ignored.
+    print_progress: bool, default True
+        Whether to display progress messages.
 
         
     Returns
@@ -343,42 +343,44 @@ def hybrid_pedigree_distribution(mig_matrix_f, mig_matrix_m, L, bingrid, whichpo
                                               number_anc=nanc_TP,
                                               Number_pops=Npops, pedigree=the_pedigree)
 
-    
-    print('-------------------------------------------------------------------\n')
-    print("".join(['Computing pedigrees probabilities...\n']))
-    print('-------------------------------------------------------------------\n')
+    if print_progress:
+        print('-------------------------------------------------------------------\n')
+        print("".join(['Computing pedigrees probabilities...\n']))
+        print('-------------------------------------------------------------------\n')
     
     if not X_chr_male:
     
-        prob_list_m_complete = Parallel(n_jobs=N_cores, verbose=10, prefer='processes')(
+        prob_list_m_complete = Parallel(n_jobs=N_cores, verbose=10*print_progress, prefer='processes')(
             delayed(prob_of_pop_setting_iteration_0)(i) for i in range(len(all_possible_migrations_TP)))
         data_prob_m = pd.DataFrame(prob_list_m_complete, columns=['which_ancestral', 'prob'])
     
         if not np.isclose(np.sum(data_prob_m.groupby(['which_ancestral']).sum().reset_index()['prob'].to_numpy()), 1):
             raise Exception('Pedigree probabilities do not sum up to one.')
 
-    prob_list_f_complete = Parallel(n_jobs=N_cores, verbose=10, prefer='processes')(
+    prob_list_f_complete = Parallel(n_jobs=N_cores, verbose=10*print_progress, prefer='processes')(
         delayed(prob_of_pop_setting_iteration_1)(i) for i in range(len(all_possible_migrations_TP)))
     data_prob_f = pd.DataFrame(prob_list_f_complete, columns=['which_ancestral', 'prob'])
 
     if not np.isclose(np.sum(data_prob_f.groupby(['which_ancestral']).sum().reset_index()['prob'].to_numpy()), 1):
         raise Exception('Pedigree probabilities do not sum up to one.')
 
-    print('-------------------------------------------------------------------\n')
-    print("".join(['Done! Computing phase-type densities conditioned to each pedigree...\n']))
-    print('-------------------------------------------------------------------\n')
-    print(len(migrations_at_TP), "densities to compute using the", Dioecious_model, "model.\n")
+    if print_progress:
+        print('-------------------------------------------------------------------\n')
+        print("".join(['Done! Computing phase-type densities conditioned to each pedigree...\n']))
+        print('-------------------------------------------------------------------\n')
+        print(len(migrations_at_TP), "densities to compute using the", Dioecious_model, "model.\n")
 
     density_hybrid_iteration = partial(density_hybrid_pedigree, migration_list=migrations_at_TP, which_pop=whichpop,
                                        D_model=Dioecious_model, T_PED=TP, which_L=L,
                                        bins=bingrid, mmat_f=mig_matrix_f, mmat_m=mig_matrix_m, rrr_f=rr_f, rrr_m=rr_m,
                                        is_X_chr=X_chr, is_X_chr_male=X_chr_male, density_function=density)
-    densities_list = Parallel(n_jobs=N_cores, verbose=10, prefer='processes')(
+    densities_list = Parallel(n_jobs=N_cores, verbose=10*print_progress, prefer='processes')(
         delayed(density_hybrid_iteration)(i) for i in range(len(migrations_at_TP)))
     
-    print('-------------------------------------------------------------------\n')
-    print("".join(['Done!\n']))
-    print('-------------------------------------------------------------------\n')
+    if print_progress:
+        print('-------------------------------------------------------------------\n')
+        print("".join(['Done!\n']))
+        print('-------------------------------------------------------------------\n')
 
     bins = None
     if density:
@@ -438,3 +440,42 @@ def hybrid_pedigree_distribution(mig_matrix_f, mig_matrix_m, L, bingrid, whichpo
     if density:
         return bins, final_density
     return bingrid, np.real(np.diff(final_density))
+
+def HP_tract_length_histogram_multi_windowed(mig_f, mig_m, TP, D_model, rr_f, rr_m, X_chr, X_chr_male, N_cores, population_number: int, bins: npt.ArrayLike,
+                                              chrom_lengths: npt.ArrayLike) -> npt.ArrayLike:
+        """Calculates the tract length histogram on multiple chromosomes of lengths `chrom_lengths`.
+        """
+        histogram = np.zeros(len(bins) - 1)
+        for L in chrom_lengths:
+            bins, new_histogram = hybrid_pedigree_distribution(mig_matrix_f = mig_f, mig_matrix_m = mig_m,\
+                 TP = TP, Dioecious_model = D_model, L = L, bingrid = bins, whichpop = population_number, \
+                    rr_f = rr_f, rr_m = rr_m, X_chr = X_chr, X_chr_male = X_chr_male,\
+                         N_cores = N_cores, density = False, freq = False, print_progress = False)
+            histogram += new_histogram
+        return histogram
+
+def HP_loglik(mig_matrix_f, mig_matrix_m, rr_f, rr_m, TP, Dioecious_model, X_chr, X_chr_male, N_cores, bins, Ls, data: list[list[int]], num_samples, cutoff=0):
+        """ Calculates the maximum-likelihood in a Poisson Random Field. Used to fit model parameters."""
+        
+        if num_samples == 0:
+            return 0
+       
+        predicted_tractlength_histogram = None
+        ll = 0
+
+        for pop in range(np.shape(mig_matrix_f)[1]):
+            predicted_tractlength_histogram = HP_tract_length_histogram_multi_windowed(mig_f=mig_matrix_f, mig_m=mig_matrix_m, \
+                TP=TP, D_model=Dioecious_model, rr_f=1, rr_m=1, X_chr=X_chr, X_chr_male=X_chr_male, N_cores=N_cores, \
+                    population_number=pop, bins=bins, chrom_lengths=Ls)
+
+            # Replace zeros with machine epsilon to avoid -Inf logarithms
+            predicted_tractlength_histogram[predicted_tractlength_histogram <= 0] = np.finfo(float).eps
+
+            ll += sum(-num_samples * predicted_tracts + data_tracts * np.log(num_samples * predicted_tracts) - gammaln(
+            data_tracts + 1.)
+                   for data_tracts, predicted_tracts in itertools.islice(
+            zip(data[pop], predicted_tractlength_histogram),
+            cutoff, len(predicted_tractlength_histogram) - 1)
+                   )           
+        
+        return ll

--- a/tracts/phase_type_distribution.py
+++ b/tracts/phase_type_distribution.py
@@ -353,17 +353,20 @@ class PhaseTypeDistribution(ABC):
        
         predicted_tractlength_histogram = None
         ll = 0
-        
+
         for pop in range(self.num_populations):
             predicted_tractlength_histogram=self.tract_length_histogram_multi_windowed(pop, bins, Ls)
-                   
+
+            # Replace zeros with machine epsilon to avoid -Inf logarithms
+            predicted_tractlength_histogram[predicted_tractlength_histogram <= 0] = np.finfo(float).eps
+
             ll += sum(-num_samples * predicted_tracts + data_tracts * np.log(num_samples * predicted_tracts) - gammaln(
             data_tracts + 1.)
                    for data_tracts, predicted_tracts in itertools.islice(
             zip(data[pop], predicted_tractlength_histogram),
             cutoff, len(predicted_tractlength_histogram) - 1)
-                   )
-
+                   )           
+        
         return ll
     
 
@@ -434,7 +437,7 @@ class PhTMonoecious(PhaseTypeDistribution):
                 'Source populations cannot contribute to the admixted population at generation 0. '
                 'Contributions at generation 0 will be ignored.')
             self.migration_matrix[0, :] = 0
-            
+
         if np.any(self.migration_matrix < 0) or np.any(np.sum(self.migration_matrix, axis=1) > 1):
             raise Exception(
                 'Contributions from source populations must be non-negative and sum up to a value in [0,1].')


### PR DESCRIPTION
Inference is now available using:

- The Monoecious (M) model,
- The Dioecious-Fine (DF) model or its hybrid-pedigree refinement (H-DF)
- The Dioecious-Coarse (DC) model or its hybrid-pedigree refinement (H-DC).

The user can now set any of the previous model for autosomal and allosomal admixture, specifying the parameters `ad_model_autosomal` and `ad_model_allosomal` in the driver file. For example, to use the Monoecious model for autosomes and the hybrid-pedigree refinement of the DC model for allosomes, set

`ad_model_autosomal : M`
`ad_model_allosomal : H-DC`.