### PR TITLE
Refine two-steps optimization

### DIFF
--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -197,6 +197,7 @@ Parameters and optimization
 - ``fix_parameters_from_ancestry_proportions``: These parameters are analytically computed from the ancestry proportions, and the optimization is restricted to the remaining parameters.
 - ``ad_model_autosomes``: The admixture model used to perform inference on autosomes. Must be either ``M`` (Monoecious), ``DC`` (Dioecious-Coarse), ``DF`` (Dioecious-Fine), ``H-DC`` (The hybrid-pedigree refinement of the Dioecious-Coarse model) or ``H-DF`` (The hybrid-pedigree refinement of the Dioecious-Fine model).
 - ``ad_model_allosomes``: The admixture model used to perform inference on allosomes. Must be either ``DC`` (Dioecious-Coarse), ``DF`` (Dioecious-Fine), ``H-DC`` (The hybrid-pedigree refinement of the Dioecious-Coarse model) or ``H-DF`` (The hybrid-pedigree refinement of the Dioecious-Fine model).
+- ``use_autosomes_for_sex_bias``: Whether to use both autosomal and allosomal data to optimize sex-bias parameters. Defaults to False, which means that only allosomes are used to optimize sex-bias parameters.
 
 .. admonition:: Using ``fix_parameters_from_ancestry_proportions``
    :class: tip
@@ -243,7 +244,7 @@ Once the :ref:`driver file<driver-file>` is ready, the inference can be run usin
 The software displays the initial parameters to be optimized, along with the ancestry proportions estimated from the sample. It then performs a two-stage optimization:
 
 - First, the parameters unrelated to sex bias are optimized using only autosomal tracts. In this stage, the ``ad_model_autosomes`` admixture model specified in the :ref:`driver file<driver-file>` is considered.
-- Next, these non–sex-bias parameters are fixed, and only the sex-bias parameters are optimized using both autosomal and allosomal tracts. In this stage, the ``ad_model_allosomes`` admixture model specified in the :ref:`driver file<driver-file>` is considered.
+- Next, these non–sex-bias parameters are fixed, and only the sex-bias parameters are optimized using (autosomal and) allosomal tracts. In this stage, the ``ad_model_allosomes`` admixture model specified in the :ref:`driver file<driver-file>` is considered.
 
 
 Outputs

--- a/example/3pops_sexbiased/ASW/ASW_three_pulses.yaml
+++ b/example/3pops_sexbiased/ASW/ASW_three_pulses.yaml
@@ -31,16 +31,16 @@ start_params:
   REUR2: 0.01:0.2
   t2: 5:8
   t3: 1:4
-  REUR_sex_bias: 0.1
-  REUR2_sex_bias: 0.1
-  RAFR_sex_bias: 0.1
+  REUR_sex_bias: 0.1:0.3
+  REUR2_sex_bias: 0.1:0.3
+  RAFR_sex_bias: 0.1:0.3
 repetitions: 3
 seed: 100
 maximum_iterations: 1000
 unknown_labels_for_smoothing: ["UNK", "centromere","miscall"] # segments with these labels will be smoother over, that is, will be filled with neighbouring ancestries up to their midpoints.  
 exclude_tracts_below_cm: 2
 npts : 50
-fix_parameters_from_ancestry_proportions: ['REUR2', 'RAFR', 'REUR2_sex_bias', 'RAFR_sex_bias']
+#fix_parameters_from_ancestry_proportions: ['REUR2', 'RAFR', 'REUR2_sex_bias', 'RAFR_sex_bias']
 
 ad_model_autosomes: M
 ad_model_allosomes: DC

--- a/example/3pops_sexbiased/ASW/ASW_two_pulses.yaml
+++ b/example/3pops_sexbiased/ASW/ASW_two_pulses.yaml
@@ -27,12 +27,12 @@ model_filename: ../models/ppp_pxx.yaml
 start_params: 
   t1: 14:16
   REUR: 0.1:0.9
-  REUR_sex_bias: 0.01
+  REUR_sex_bias: 0.1:0.3
   t2: 4:8
   REUR2: 0.1:0.8
-  REUR2_sex_bias: 0.1
+  REUR2_sex_bias: 0.1:0.3
   RNAT: 0.1:0.9
-  RNAT_sex_bias: 0.1
+  RNAT_sex_bias: 0.1:0.3
 
 repetitions: 5
 seed: 100
@@ -40,7 +40,7 @@ maximum_iterations: 1000
 unknown_labels_for_smoothing: ["UNK", "centromere","miscall"] # segments with these labels will be smoother over, that is, will be filled with neighbouring ancestries up to their midpoints.  
 exclude_tracts_below_cm: 2
 npts : 50
-fix_parameters_from_ancestry_proportions: ['REUR2', 'RNAT', 'REUR2_sex_bias', 'RNAT_sex_bias']
+#fix_parameters_from_ancestry_proportions: ['REUR2', 'RNAT', 'REUR2_sex_bias', 'RNAT_sex_bias']
 
 ad_model_autosomes: M
 ad_model_allosomes: DC

--- a/example/documentation_examples/ASW/ASW_three_pulses.yaml
+++ b/example/documentation_examples/ASW/ASW_three_pulses.yaml
@@ -31,9 +31,9 @@ start_params:
   REUR2: 0.2
   t2: 5:8
   t3: 1:4
-  REUR_sex_bias: 0.1
-  REUR2_sex_bias: 0.1
-  RAFR_sex_bias: 0.1
+  REUR_sex_bias: -0.5:0.5
+  REUR2_sex_bias: -0.5:0.5
+  RAFR_sex_bias: -0.5:0.5
 repetitions: 3
 seed: 100
 maximum_iterations: 1000

--- a/example/documentation_examples/MXL/MXL_continuous.yaml
+++ b/example/documentation_examples/MXL/MXL_continuous.yaml
@@ -33,9 +33,9 @@ start_params:
   RNAT: 0.2
   t2: 6:8
   
-  REUR_sex_bias: -0.8 # more males
-  RNAT_sex_bias: 0.8 # more females
-  RAFR_sex_bias: -0.1
+  REUR_sex_bias: -0.8:0.8 
+  RNAT_sex_bias: -0.8:0.8
+  RAFR_sex_bias: -0.5:0.5
 repetitions: 3
 seed: 100
 maximum_iterations: 1000

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,642 @@
+"""
+Tests for sex-biased optimizers in tracts/core.py.
+
+The tests use lightweight mocks so that no real tract data or costly model
+evaluations are needed.  The Population mock returns pre-computed constant
+histogram arrays; fmin_cobyla is patched to return x0 unchanged so we can
+inspect what the optimizers would have been called with without running real
+phase-type computations. Tests that only need to exercise the validation
+logic (raises before fmin_cobyla is called) do not need the patch.
+"""
+
+import logging
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+import tracts.core as core_module
+from tracts.core import optimize_cob_sex_biased_single_step, optimize_cob_sex_biased_two_steps
+from tracts.demography.parametrized_demography_sex_biased import ParametrizedDemographySexBiased
+from tracts.demography.base_parametrized_demography import FixedParametersHandler
+from tracts.demography.parameter import ParamType
+from tracts.demography.parametrized_demography_sex_biased import SexType
+
+
+# --------------- Helpers / shared fixtures ---------------
+
+N_PARAMS = 4  # 2 non-sex-bias (t, rate_eur) + 2 sex-bias (sb_eur, sb_afr)
+N_BINS   = 5
+N_POPS   = 2  # populations A, B
+P0      = np.array([5.0, 0.3, 0.05, 0.05])   # [t, rate_eur, sb_eur, sb_afr]
+P_DICT  = {"A": 0, "B": 1}
+
+def _make_demography():
+    """
+    Return a minimal ParametrizedDemographySexBiased with two sex-bias params.
+    """
+    dem = ParametrizedDemographySexBiased()
+    dem.add_parameter("t",       ParamType.TIME)
+    dem.add_parameter("rate_eur",ParamType.RATE)
+    dem.add_parameter("sb_eur",  ParamType.SEX_BIAS)
+    dem.add_parameter("sb_afr",  ParamType.SEX_BIAS)
+    return dem
+
+def _make_handler(dem=None):
+    """
+    Return a FixedParametersHandler wired to *dem* with no parameters fixed.    
+    """
+    if dem is None:
+        dem = _make_demography()
+    ph = FixedParametersHandler(logging.getLogger("test"))
+    ph.set_up_fixed_parameters(dem, params_to_fix_by_ancestry=[], proportions={})
+    return ph
+
+
+def _make_population():
+    """
+    Return a mock Population whose data accessors return constant arrays.
+    """
+    pop = MagicMock()
+
+    bins   = np.linspace(0, 1, N_BINS + 1)
+    counts = np.zeros(N_BINS, dtype="int64").tolist()
+
+    pop.get_global_tractlengths.return_value = (bins, {"A": counts, "B": counts})
+    pop.get_global_allosome_tractlengths.return_value = (
+        bins,
+        {
+            SexType.FEMALE: {"A": counts, "B": counts},
+            SexType.MALE:   {"A": counts, "B": counts},
+        },
+    )
+    pop.Ls             = [1.0]
+    pop.indivs         = [MagicMock()] * 10
+    pop.num_males      = 5
+    pop.num_females    = 5
+    pop.allosome_lengths = {"X": 1.0}
+    return pop
+
+def _make_model_func():
+    """
+    Dummy model_func – never actually called (fmin_cobyla is always patched).
+    """
+    mat = np.array([[0.5, 0.5]])
+
+    def model_func(params):
+        return {"female": mat, "male": mat}
+
+    return model_func
+
+
+def _always_valid(params):
+    """
+    outofbounds_fun that always returns +1 (never out of bounds).
+    """
+    return 1.0
+
+def _fake_fmin(func, x0, cons, **kwargs):
+    """
+    fmin_cobyla mock: returns x0 unchanged without calling the objective.
+    """
+    return x0
+
+
+# Common kwargs shared by most calls; tests override what they need.
+COMMON_KWARGS = dict(
+    p0                    = P0,
+    population            = None,   # replaced per test
+    model_func            = _make_model_func(),
+    parameter_handler     = None,   # replaced per test
+    outofbounds_fun       = _always_valid,
+    verbose_log           = 0,
+    verbose_screen        = 0,
+    p_dict                = P_DICT,
+    exclude_tracts_below_cM = 0,
+    maxiter               = 2,
+    reset_counter         = True,
+    ad_model_autosomes    = "DC",
+    ad_model_allosomes    = "DC",
+    autosomes_in_step_2   = True,
+    npts                  = N_BINS,
+)
+
+
+def _call(steps=None, patch_fmin=True, **overrides):
+    """
+    Invoke optimize_cob_sex_biased_two_steps with the common fixture.
+
+    When *patch_fmin* is True (default) scipy.optimize.fmin_cobyla is replaced
+    with a stub that returns x0 unchanged, avoiding any real phase-type call.
+    Set patch_fmin=False only for tests that raise before fmin_cobyla is reached.
+    """
+    kwargs = dict(COMMON_KWARGS)
+    kwargs["population"]         = _make_population()
+    kwargs["parameter_handler"]  = _make_handler()
+    kwargs["steps"]              = steps
+    kwargs.update(overrides)
+
+    if patch_fmin:
+        with patch.object(core_module.scipy.optimize, "fmin_cobyla", side_effect=_fake_fmin):
+            return optimize_cob_sex_biased_two_steps(**kwargs)
+    else:
+        return optimize_cob_sex_biased_two_steps(**kwargs)
+
+
+def _call_single(patch_fmin=True, **overrides):
+    """
+    Invoke optimize_cob_sex_biased_single_step with the common fixture.
+
+    When *patch_fmin* is True (default) scipy.optimize.fmin_cobyla is replaced
+    with a stub that returns x0 unchanged.
+    """
+    kwargs = dict(COMMON_KWARGS)
+    kwargs["population"] = _make_population()
+    kwargs["parameter_handler"] = _make_handler()
+    kwargs.pop("steps", None)
+    kwargs.pop("autosomes_in_step_2", None)
+    kwargs.update(overrides)
+
+    if patch_fmin:
+        with patch.object(core_module.scipy.optimize, "fmin_cobyla", side_effect=_fake_fmin):
+            return optimize_cob_sex_biased_single_step(**kwargs)
+    return optimize_cob_sex_biased_single_step(**kwargs)
+
+
+# --------------- Steps argument validation ---------------
+
+class TestStepsValidation:
+    """
+    This class contains tests for the validation logic of the *steps* argument to optimize_cob_sex_biased_two_steps.
+    The tests verify that valid specifications are accepted and invalid ones raise the appropriate exceptions with informative messages. 
+    It also checks that the default behavior (steps=None) runs without error and returns a valid output type, as this is a common usage pattern.
+    """
+
+    def test_none_runs_both_steps(self):
+        """
+        Checks that steps=None must run without error (default: both steps).
+        """
+        params, lik = _call(steps=None)
+        assert isinstance(params, np.ndarray)
+        assert np.isfinite(lik) or lik == -1e32  # finite or hard fallback
+
+    @pytest.mark.parametrize("steps", [
+        [1], ["step1"],
+        [2], ["step2"],
+        [1, 2], ["step1", "step2"], [1, "step2"], ["step1", 2],
+    ])
+
+    def test_valid_steps_accepted(self, steps):
+        """
+        Checks that all documented valid step specifications are accepted.
+        """
+        # step 2 requires allosomal data already set in COMMON_KWARGS
+        params, lik = _call(steps=steps)
+        assert isinstance(params, np.ndarray)
+
+    def test_not_a_list_raises_type_error(self):
+        """
+        Checks that a non-list steps argument raises TypeError.
+        """
+        with pytest.raises(TypeError):
+            _call(steps=1)
+
+    def test_empty_list_raises_value_error(self):
+        """
+        Checks that an empty list for steps raises ValueError, as it does not specify any valid step.
+        """
+        with pytest.raises(ValueError, match="empty"):
+            _call(steps=[])
+
+    def test_invalid_step_value_raises_value_error(self):
+        """
+        Checks that invalid step values (e.g., 3 or "step3") raise ValueError with an informative message.
+        """
+        with pytest.raises(ValueError, match="Invalid step value"):
+            _call(steps=[3])
+
+    def test_invalid_string_raises_value_error(self):
+        """
+        Checks that invalid string step values (e.g., "step3") raise ValueError with an informative message.
+        """
+        with pytest.raises(ValueError, match="Invalid step value"):
+            _call(steps=["step3"])
+
+    def test_duplicate_step_integer_raises(self):
+        """
+        Checks that [1, 1] duplicates step 1.
+        """
+        with pytest.raises(ValueError, match="duplicate"):
+            _call(steps=[1, 1])
+
+    def test_duplicate_step_mixed_raises(self):
+        """
+        Checks that [1, 'step1'] references step 1 twice.
+        """
+        with pytest.raises(ValueError, match="duplicate"):
+            _call(steps=[1, "step1"])
+
+    def test_duplicate_step_2_raises(self):
+        """
+        Checks that [2, "step2"] duplicates step 2.
+        """
+        with pytest.raises(ValueError, match="duplicate"):
+            _call(steps=[2, "step2"])
+
+
+# --------------- Tests for the ad_model_allosomes constraint ---------------
+
+class TestAllosomeModelConstraint:
+    """
+    This class contains tests for the requirement that step 2 of optimize_cob_sex_biased_two_steps must have an allosomal model specified.
+    The tests verify that attempting to run step 2 without an allosomal model raises a ValueError with an informative message, 
+    and that step 1 only does not require an allosomal model.
+    """
+
+    def test_step2_without_allosome_model_raises(self):
+        """
+        Checks that step 2 without an allosomal model raises ValueError, as step 2 relies on allosomal data to estimate sex bias. 
+        The error message should mention "ad_model_allosomes" to guide the user to the missing argument.
+        """
+        with pytest.raises(ValueError, match="ad_model_allosomes"):
+            _call(steps=[2], ad_model_allosomes=None)
+
+    def test_step2_both_without_allosome_model_downgrades(self):
+        """
+        Checks that running both steps without an allosomal model auto-downgrades to step 1 only
+        without raising an error, since step 1 does not require allosomal data.
+        """
+        params, lik = _call(steps=[1, 2], ad_model_allosomes=None)
+        assert isinstance(params, np.ndarray)
+        assert isinstance(lik, float)
+
+    def test_step1_only_none_allosome_model_allowed(self):
+        """
+        Checks that step 1 only does not require an allosomal model and runs without error even if ad_model_allosomes
+        is None, since step 1 does not use allosomal data.
+        """
+        params, lik = _call(steps=[1], ad_model_allosomes=None)
+        assert isinstance(params, np.ndarray)
+
+
+# --------------- Tests for parameter fixing semantics per mode ---------------
+
+class TestParameterFixingSemantics:
+    """
+    This class checks that each mode optimizes over exactly the right parameter subset.
+    The functions capture the local FixedParametersHandler seen by the optimizer
+    and assert the exact free parameter labels at each fmin_cobyla call.
+    """
+
+    def _extract_handler_from_callable(self, func):
+        """
+        Walk a callable closure to find the local FixedParametersHandler instance.
+        """
+        seen = set()
+
+        def visit(obj):
+            obj_id = id(obj)
+            if obj_id in seen:
+                return None
+            seen.add(obj_id)
+
+            if isinstance(obj, FixedParametersHandler):
+                return obj
+
+            closure = getattr(obj, "__closure__", None)
+            if closure is None:
+                return None
+
+            for cell in closure:
+                try:
+                    cell_value = cell.cell_contents
+                except ValueError:
+                    continue
+                found = visit(cell_value)
+                if found is not None:
+                    return found
+            return None
+
+        handler = visit(func)
+        if handler is None:
+            raise AssertionError("Could not extract FixedParametersHandler from optimizer callback closure.")
+        return handler
+
+    def _run_and_capture_free_labels(self, steps, **extra):
+        """
+        Runs the two-step optimizer and returns a list of free parameter label
+        lists, one per fmin_cobyla call, captured from the local handler closure.
+        """
+        captured = []
+
+        def capturing_fmin(func, x0, cons, **kwargs):
+            handler = self._extract_handler_from_callable(func)
+            captured.append(handler.indices_to_labels(handler.free_parameters_indices))
+            return x0
+
+        with patch.object(core_module.scipy.optimize, "fmin_cobyla", side_effect=capturing_fmin):
+            _call(steps=steps, patch_fmin=False, **extra)
+
+        return captured
+
+    def test_step1_only_optimises_non_sex_bias(self):
+        """ 
+        Checks that step 1 only optimizes non-sex-bias parameters.
+        """
+        captured = self._run_and_capture_free_labels(steps=[1])
+        assert len(captured) == 1, "exactly one fmin_cobyla call expected"
+        assert captured[0] == ["t", "rate_eur"]
+
+    def test_step2_only_optimises_sex_bias(self):
+        """
+        Checks that step 2 only optimizes sex-bias parameters, with non-sex-bias parameters fixed.
+        """
+        captured = self._run_and_capture_free_labels(steps=[2])
+        assert len(captured) == 1
+        assert captured[0] == ["sb_eur", "sb_afr"]
+
+    def test_both_steps_two_fmin_calls(self):
+        """
+        Checks that running both steps results in two calls to fmin_cobyla, one for each step,
+        with the appropriate parameter subsets free in each.
+        """
+        captured = self._run_and_capture_free_labels(steps=[1, 2])
+        assert len(captured) == 2
+
+    def test_step1_in_combined_optimises_non_sex_bias(self):
+        """
+        Checks that in combined mode, step 1 optimizes the non-sex-bias parameters (t and rate_eur) while sex-bias parameters are fixed.
+        """
+        captured = self._run_and_capture_free_labels(steps=[1, 2])
+        assert captured[0] == ["t", "rate_eur"]
+
+    def test_step2_in_combined_optimises_sex_bias(self):
+        """
+        Checks that in combined mode, step 2 optimizes the sex-bias parameters (sb_eur and sb_afr) while non-sex-bias parameters are fixed.
+        """
+        captured = self._run_and_capture_free_labels(steps=[1, 2])
+        assert captured[1] == ["sb_eur", "sb_afr"]
+
+
+# --------------- Tests for best-likelihood tracking scoped to the active step ---------------
+
+class TestBestLikelihoodTracking:
+    """
+    This class verifies that the best-likelihood tracking is correctly scoped to the active step(s) and does not cross-contaminate between steps.
+    In particular, verifies that:
+    - Step 1 only: returned likelihood reflects the best seen during step 1.
+    - Step 2 only: returned likelihood reflects the best seen during step 2.
+    - Both steps: the returned likelihood is the best from step 2, not the
+      global best across both steps.
+    """
+
+    def _run_tracking_test(self, steps):
+        """
+        Return the likelihood reported by the function.  We patch fmin_cobyla
+        to return the initial x0 unchanged so the function always evaluates
+        at p0; the exact value does not matter, only that it is consistent.
+        """
+        _, lik = _call(steps=steps)
+        return lik
+
+    def test_step1_only_returns_finite_or_fallback(self):
+        lik = self._run_tracking_test(steps=[1])
+        assert np.isfinite(lik) or lik == -1e32
+
+    def test_step2_only_returns_finite_or_fallback(self):
+        lik = self._run_tracking_test(steps=[2])
+        assert np.isfinite(lik) or lik == -1e32
+
+    def test_both_steps_returns_finite_or_fallback(self):
+        lik = self._run_tracking_test(steps=[1, 2])
+        assert np.isfinite(lik) or lik == -1e32
+
+    def test_step2_best_resets_between_steps(self):
+        """
+        Verify that the best objective is reset before step 2 by checking that
+        two independent runs (step-1-only vs step-2-only) do not share state.
+        """
+        _, lik_s1 = _call(steps=[1])
+        _, lik_s2 = _call(steps=[2])
+        # Both should be a real number (even if very negative); not cross-contaminated
+        assert np.isfinite(lik_s1) or lik_s1 == -1e32
+        assert np.isfinite(lik_s2) or lik_s2 == -1e32
+
+
+# --------------- Tests that parameter autosomes_in_step_2 controls data scope in step 2 ---------------
+
+class TestAutosomesInStep2:
+
+    def _run_and_capture_include_autosomes(self, steps, autosomes_in_step_2):
+        """
+        Capture the include_autosomes value that was passed to the step-2 objective.
+        We do this by recording the x0 size and any calls; the objective itself
+        is not called here, but we verify no ValueError is raised.
+        """
+        params, lik = _call(steps=steps, autosomes_in_step_2=autosomes_in_step_2)
+        return params, lik
+
+    def test_autosomes_in_step2_true_no_error(self):
+        """
+        Tests that autosomes_in_step_2=True runs without error and returns a parameter array,
+        indicating that the step-2 objective was able to include autosomal data as intended.
+        """    
+        params, lik = self._run_and_capture_include_autosomes([2], autosomes_in_step_2=True)
+        assert isinstance(params, np.ndarray)
+
+    def test_autosomes_in_step2_false_no_error(self):
+        """
+        Tests that autosomes_in_step_2=False runs without error and returns a parameter array,
+        indicating that the step-2 objective was able to exclude autosomal data and focus on allosomal data as intended.
+        """
+        params, lik = self._run_and_capture_include_autosomes([2], autosomes_in_step_2=False)
+        assert isinstance(params, np.ndarray)
+
+    def test_autosomes_in_step2_false_requires_allosome_model(self):
+        """
+        Tests that autosomes_in_step_2=False raises ValueError if ad_model_allosomes is None,
+        since excluding autosomal data in step 2 requires an allosomal model to be specified
+        for the optimization to proceed.
+        """
+        with pytest.raises(ValueError):
+            _call(steps=[2], autosomes_in_step_2=False, ad_model_allosomes=None)
+
+
+# --------------- Tests for return type and shape ---------------
+
+class TestReturnTypeAndShape:
+
+    @pytest.mark.parametrize("steps", [[1], [2], [1, 2], None])
+    def test_returns_tuple_of_array_and_float(self, steps):
+        """
+        Tests that the function returns a tuple of (params, lik) where params is a numpy array and lik is a float,
+        for all valid step specifications including the default None. This ensures that the output format is
+        consistent regardless of which steps are run.
+        """
+        result = _call(steps=steps)
+        assert isinstance(result, tuple) and len(result) == 2
+        params, lik = result
+        assert isinstance(params, np.ndarray)
+        assert isinstance(lik, float)
+
+    @pytest.mark.parametrize("steps", [[1], [2], [1, 2], None])
+    def test_returned_params_have_correct_length(self, steps):
+        """
+        Tests that the returned parameter array has the expected length (N_PARAMS) for all valid step specifications,
+        including the default None. This verifies that the function returns a complete parameter vector regardless of which steps are executed.
+        """
+        params, _ = _call(steps=steps)
+        assert len(params) == N_PARAMS
+
+
+# ---------------  Tests for reset_counter behaviour ---------------
+
+class TestResetCounter:
+    """
+    This class verifies that the reset_counter argument correctly controls whether the internal optimization counter is reset to zero before optimization begins.
+    """
+
+    def test_reset_counter_true_resets_to_zero(self):
+        """
+        Tests that when reset_counter=True, the internal counter is reset to zero before optimization begins.
+        """
+        core_module._counter = 999
+        _call(steps=[1], reset_counter=True)
+        assert core_module._counter < 999 # Counter will have been incremented at least once from 0; it will not be 999+.
+
+    def test_reset_counter_false_preserves_count(self):
+        """
+        Tests that when reset_counter=False, the internal counter is not reset and retains its value from previous runs,
+        allowing for cumulative counting across multiple calls if desired.
+        """
+        core_module._counter = 0
+        _call(steps=[1], reset_counter=True)
+        count_after_first = core_module._counter
+        _call(steps=[1], reset_counter=False)
+        assert core_module._counter > count_after_first # Counter must have grown (not been reset to 0)
+
+
+# ---------------  Tests for p0 used as starting point in step-2-only mode ---------------
+
+class TestStep2OnlyStartingPoint:
+
+    def test_step2_only_x0_derived_from_p0(self):
+        """
+        Tests that in step-2-only mode, the initial parameter vector (x0) passed to fmin_cobyla is derived
+        from the input p0, specifically taking the sex-bias parameters from p0 and not the non-sex-bias parameters.
+        """
+        captured_x0 = []
+
+        def capture(func, x0, cons, **kw):
+            captured_x0.append(x0.copy())
+            return x0
+
+        with patch.object(core_module.scipy.optimize, "fmin_cobyla", side_effect=capture):
+            _call(steps=[2], p0=P0, patch_fmin=False)
+
+        assert len(captured_x0) == 1
+        # sb_eur=0.05, sb_afr=0.05 are the sex-bias values in P0
+        np.testing.assert_allclose(captured_x0[0], P0[[2, 3]], rtol=1e-6)
+
+
+# --------------- Test for optimize_cob_sex_biased_single_step ---------------
+
+class TestSingleStepBasicModes:
+    """
+    This class contains basic tests for optimize_cob_sex_biased_single_step to verify that it runs without error
+    and returns outputs of the expected type and shape, both with and without an allosomal model specified.
+    These tests do not check the internal logic of the optimization but ensure that the function can be invoked in
+    its basic modes and that it handles the presence or absence of an allosomal model as expected.
+    """
+
+    @pytest.mark.parametrize("ad_model_allosomes", ["DC", None])
+    def test_single_step_accepts_with_or_without_allosomes(self, ad_model_allosomes):
+        """
+        Tests that the function accepts both with and without an allosomal model specified.
+        """
+        params, lik = _call_single(ad_model_allosomes=ad_model_allosomes)
+        assert isinstance(params, np.ndarray)
+        assert len(params) == N_PARAMS
+        assert np.isfinite(lik) or lik == -1e32
+
+    def test_single_step_returns_tuple_array_float(self):
+        """
+        Tests that the function returns a tuple containing a numpy array and a float.
+        """
+        result = _call_single()
+        assert isinstance(result, tuple) and len(result) == 2
+        params, lik = result
+        assert isinstance(params, np.ndarray)
+        assert isinstance(lik, float)
+        assert len(params) == N_PARAMS
+
+
+class TestSingleStepOptimizerCall:
+    """
+    This class contains tests to verify that optimize_cob_sex_biased_single_step makes exactly one call to scipy.optimize.fmin_cobyla
+    and that the initial parameter vector (x0) passed to fmin_cobyla is derived from the input p0 as expected, specifically that it includes
+    the full parameter vector and not just a subset. These tests use a mock for fmin_cobyla to capture the calls and inspect the arguments
+    without performing any real optimization.
+    """
+
+    def test_single_step_calls_fmin_once(self):
+        """
+        Tests that optimize_cob_sex_biased_single_step makes exactly one call to scipy.optimize.fmin_cobyla, ensuring
+        that the optimization process is initiated as expected and that there are no unexpected multiple calls to the optimizer.
+        """
+        call_count = 0
+
+        def capture(func, x0, cons, **kw):
+            nonlocal call_count
+            call_count += 1
+            return x0
+
+        with patch.object(core_module.scipy.optimize, "fmin_cobyla", side_effect=capture):
+            _call_single(patch_fmin=False)
+
+        assert call_count == 1
+
+    def test_single_step_x0_is_full_parameter_vector(self):
+        """
+        Tests that the initial parameter vector (x0) passed to fmin_cobyla in optimize_cob_sex_biased_single_step is the full parameter
+        vector derived from the input p0, rather than a subset, ensuring that the optimization is correctly initialized with all parameters
+        available for optimization.
+        """
+        captured_x0 = []
+
+        def capture(func, x0, cons, **kw):
+            captured_x0.append(np.array(x0, copy=True))
+            return x0
+
+        with patch.object(core_module.scipy.optimize, "fmin_cobyla", side_effect=capture):
+            _call_single(p0=P0, patch_fmin=False)
+
+        assert len(captured_x0) == 1
+        np.testing.assert_allclose(captured_x0[0], P0, rtol=1e-6)
+
+
+class TestSingleStepResetCounter:
+    """
+    This class contains tests to verify that the reset_counter argument in optimize_cob_sex_biased_single_step correctly
+    controls whether the internal optimization counter is reset to zero before optimization begins.
+    """
+
+    def test_single_step_reset_counter_true_resets_to_zero(self):
+        """
+        Tests that when reset_counter=True, the internal counter is reset to zero before optimization begins,
+        ensuring that the optimization process starts with a clean state and that the counter does not carry over from previous runs.
+        """
+        core_module._counter = 999
+        _call_single(reset_counter=True)
+        assert core_module._counter < 999
+
+    def test_single_step_reset_counter_false_preserves_count(self):
+        """
+        Tests that when reset_counter=False, the internal counter is not reset and retains its value from previous runs,
+        allowing for cumulative counting across multiple calls if desired, and that the counter continues to increment from its
+        previous value rather than resetting to zero.
+        """
+        core_module._counter = 0
+        _call_single(reset_counter=True)
+        count_after_first = core_module._counter
+        _call_single(reset_counter=False)
+        assert core_module._counter > count_after_first

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,9 +1,15 @@
 import os
 import pytest
 import shutil
-from tracts.driver import run_tracts
+from collections import OrderedDict
+from types import SimpleNamespace
 from pathlib import Path
 import numpy as np
+
+import tracts.driver as driver_module
+from tracts.driver import run_tracts
+from tracts.demography.parameter import ParamType
+from tracts.driver_utils import _print_run_intro as real_print_run_intro
 
 # ------------ Helper functions for test setup and checks ----------
 
@@ -58,6 +64,226 @@ def _clean_output_dir(output_dir: Path):
 
     if output_dir.exists():
         shutil.rmtree(output_dir)
+
+
+def _make_mock_driver_spec(tmp_path: Path, two_steps_optimization: bool, autosomes_in_step_2: bool):
+    """
+    Return a minimal driver-spec SimpleNamespace that covers the two-step and allosome flags.
+    The specific values are not important, but they should be plausible and consistent with the expected types.
+    """
+    return SimpleNamespace(
+        log_filename="test_logfile.log",
+        output_directory=str(tmp_path / "test_output"),
+        exclude_tracts_below_cm=0,
+        npts=5,
+        ad_model_autosomes="DC",
+        ad_model_allosomes="DC",
+        samples=SimpleNamespace(allosomes=["X"]),
+        unknown_labels_for_smoothing=[],
+        model_filename="test_model.yaml",
+        start_params=SimpleNamespace(),
+        repetitions=2,
+        seed=1,
+        maximum_iterations=2,
+        verbose_log=0,
+        verbose_screen=0,
+        fix_parameters_from_ancestry_proportions=[],
+        output_filename_format="test_output_{label}",
+        two_steps_optimization=two_steps_optimization,
+        autosomes_in_step_2=autosomes_in_step_2,
+        use_autosomes_for_sex_bias=autosomes_in_step_2,
+        log_scale=False,
+    )
+
+
+def _make_mock_model():
+    """
+    Return a minimal model SimpleNamespace with four parameters:
+      - t        (TIME,     index 0)
+      - rate_eur (RATE,     index 1)
+      - sb_eur   (SEX_BIAS, index 2)
+      - sb_afr   (SEX_BIAS, index 3)
+
+    Indices 0–1 are non-sex-bias (replaced by Step 1 best in two-step runs).
+    Indices 2–3 are sex-bias (kept run-specific in Step 2).
+    """
+    model = SimpleNamespace()
+    model.model_base_params = OrderedDict([
+        ("t", SimpleNamespace(index=0, type=ParamType.TIME)),
+        ("rate_eur", SimpleNamespace(index=1, type=ParamType.RATE)),
+        ("sb_eur", SimpleNamespace(index=2, type=ParamType.SEX_BIAS)),
+        ("sb_afr", SimpleNamespace(index=3, type=ParamType.SEX_BIAS)),
+    ])
+    model.population_indices = OrderedDict([("A", 0), ("B", 1)])
+    model.parametrized_populations = ["pop"]
+    model.parameter_handler = SimpleNamespace(
+        to_physical_params_functions={},
+        to_optimizer_params_functions={},
+        enable_time_param_logging=True,
+        convert_to_optimizer_params=lambda params: np.array(params, dtype=float),
+        convert_to_physical_params=lambda params, report_non_admissible=False: np.array(params, dtype=float),
+        set_up_fixed_parameters=lambda *args, **kwargs: None,
+        release_fixed_parameters=lambda *args, **kwargs: None,
+        add_fixed_parameters=lambda *args, **kwargs: None,
+    )
+    model.proportions_from_matrices = lambda matrices: {"A": np.array([1.0])}
+    model.get_violation_score = lambda params, verbose=False: 1.0
+    model.get_migration_matrices = lambda params: {"female": np.zeros((1, 1)), "male": np.zeros((1, 1))}
+    model.set_up_fixed_parameters = lambda *args, **kwargs: None
+    return model
+
+
+def _make_mock_population():
+    """
+    Return a minimal population SimpleNamespace with stub data sufficient for driver book-keeping.
+    The specific values are not important, but they should be plausible and consistent with the expected types.
+    """
+    population = SimpleNamespace()
+    population.get_global_tractlengths = lambda npts, exclude_tracts_below_cM: (
+        np.linspace(0, 1, 6),
+        {"A": [0, 0, 0, 0, 0], "B": [0, 0, 0, 0, 0]},
+    )
+    population.calculate_ancestry_proportions = lambda ancestor_labels: np.array([0.6, 0.4])
+    population.calculate_allosome_proportions = lambda population_labels, allosome_label: np.array([0.6, 0.4])
+    population.smooth_unknowns = lambda allosome_labels: None
+    population.unknown_labels = []
+    population.Ls = [1.0]
+    population.indivs = [object()]
+    population.nind = 1
+    population.num_males = 1
+    population.num_females = 1
+    population.allosome_lengths = {"X": 1.0}
+    return population
+
+
+def _install_driver_run_mocks(monkeypatch, tmp_path: Path, two_steps_optimization: bool, autosomes_in_step_2: bool):
+    """
+    Patch all I/O and optimizer calls in ``tracts.driver`` so that ``run_tracts`` can be
+    exercised without touching the file system or running a real optimization. ``fake_run_model_multi_init`` 
+    records every call into ``recorded_runs`` and returns deterministic dummy results:
+      - Step 1 best is [11, 22, 101, 201] / [12, 23, 102, 202] with likelihoods [2.0, 1.0]
+        (best → run 0: [11, 22, 101, 201]).
+      - Step 2 returns plausible values that are not checked here.
+    ``recording_print_run_intro`` wraps the real implementation and appends
+    every ``title_message`` to ``recorded_titles`` so tests can inspect table headers.
+    Returns (driver_spec, model, population, recorded_titles, recorded_runs,
+    recorded_parse_calls, recorded_collapse_calls)
+    """
+    driver_spec = _make_mock_driver_spec(tmp_path, two_steps_optimization, autosomes_in_step_2)
+    model = _make_mock_model()
+    population = _make_mock_population()
+    recorded_titles = []
+    recorded_runs = []
+    recorded_parse_calls = []
+    recorded_collapse_calls = []
+
+    def recording_print_run_intro(*args, **kwargs):
+        if "title_message" in kwargs:
+            recorded_titles.append(kwargs["title_message"])
+        else:
+            recorded_titles.append(args[4])
+        return real_print_run_intro(*args, **kwargs)
+
+    def fake_run_model_multi_init(*, start_params_list, steps=None, autosomes_in_step_2=None, **kwargs):
+        normalized_start_params = [np.array(params, dtype=float) for params in start_params_list]
+        recorded_runs.append(
+            {
+                "steps": steps,
+                "autosomes_in_step_2": autosomes_in_step_2,
+                "start_params_list": normalized_start_params,
+            }
+        )
+
+        if steps == [1]:
+            return (
+                [
+                    np.array([11.0, 22.0, 101.0, 201.0]),
+                    np.array([12.0, 23.0, 102.0, 202.0]),
+                ],
+                [2.0, 1.0],
+            )
+
+        if steps == [2]:
+            return (
+                [
+                    np.array([11.0, 22.0, 301.0, 401.0]),
+                    np.array([11.0, 22.0, 302.0, 402.0]),
+                ],
+                [5.0, 4.0],
+            )
+
+        return ([np.array([1.0, 2.0, 3.0, 4.0])], [1.0])
+
+    def fake_parse_start_params(*, sample_param_names=None, fixed_param_values=None, **kwargs):
+        sample_param_names = set(sample_param_names) if sample_param_names is not None else None
+        fixed_param_values = {} if fixed_param_values is None else dict(fixed_param_values)
+
+        recorded_parse_calls.append(
+            {
+                "sample_param_names": sample_param_names,
+                "fixed_param_values": fixed_param_values,
+            }
+        )
+
+        if sample_param_names == {"t", "rate_eur"}:
+            return [
+                np.array([1.0, 2.0, 0.0, 0.0]),
+                np.array([10.0, 20.0, 0.0, 0.0]),
+            ]
+
+        if sample_param_names == {"sb_eur", "sb_afr"}:
+            return [
+                np.array([fixed_param_values["t"], fixed_param_values["rate_eur"], 3.0, 4.0]),
+                np.array([fixed_param_values["t"], fixed_param_values["rate_eur"], 30.0, 40.0]),
+            ]
+
+        return [
+            np.array([1.0, 2.0, 3.0, 4.0]),
+            np.array([10.0, 20.0, 30.0, 40.0]),
+        ]
+
+    def fake_collapse_identical_start_params(start_params, step_label):
+        recorded_collapse_calls.append(
+            {
+                "step_label": step_label,
+                "start_params": [np.array(params, dtype=float) for params in start_params],
+            }
+        )
+        return start_params
+
+    monkeypatch.setattr(driver_module, "locate_file_path", lambda filename, script_dir: Path("/tmp/test_driver.yaml"))
+    monkeypatch.setattr(driver_module, "load_driver_file", lambda driver_path: driver_spec)
+    monkeypatch.setattr(driver_module, "load_population", lambda **kwargs: population)
+    monkeypatch.setattr(driver_module, "load_model_from_driver", lambda **kwargs: model)
+    monkeypatch.setattr(driver_module, "parse_start_params", fake_parse_start_params)
+    monkeypatch.setattr(driver_module, "collapse_identical_start_params", fake_collapse_identical_start_params)
+    monkeypatch.setattr(driver_module, "get_time_scaled_model_func", lambda model: (lambda params: params))
+    monkeypatch.setattr(driver_module, "get_time_scaled_model_bounds", lambda model: (lambda params: 1.0))
+    monkeypatch.setattr(driver_module, "run_model_multi_init", fake_run_model_multi_init)
+    monkeypatch.setattr(driver_module, "output_simulation_data_sex_biased", lambda **kwargs: None)
+    monkeypatch.setattr(driver_module, "setup_logger", lambda: (driver_module.logger, SimpleNamespace()))
+    monkeypatch.setattr(driver_module, "set_log_file", lambda **kwargs: None)
+    monkeypatch.setattr(driver_module, "close_log_file", lambda **kwargs: None)
+    monkeypatch.setattr(driver_module, "_print_run_intro", recording_print_run_intro)
+
+    return (
+        driver_spec,
+        model,
+        population,
+        recorded_titles,
+        recorded_runs,
+        recorded_parse_calls,
+        recorded_collapse_calls,
+    )
+
+
+def _assert_arrays_list_equal(actual, expected):
+    """
+    Assert two lists of numpy arrays are element-wise equal (via ``assert_allclose``).
+    """
+    assert len(actual) == len(expected)
+    for actual_item, expected_item in zip(actual, expected):
+        np.testing.assert_allclose(actual_item, expected_item)
 
 # ------------ Test functions ----------
 
@@ -259,3 +485,71 @@ def test_compare_only_autosomal_one_step_vs_two_steps(tmp_path):
         _prepare_driver(script_dir / "test_two_steps_only_autosomes_fix.yaml", output_dir),
     ]
     _compare_driver_results(driver_files_fix, script_dir, output_dir)
+
+
+def test_run_tracts_two_steps_reuses_step1_values_for_step2_start_params(tmp_path, monkeypatch, capsys):
+    """
+    Verify that two-step runs print separate Step 1 and Step 2 starting-parameter tables and that Step 2
+    starts from Step 1's best non-sex-bias parameters while preserving run-specific sex-bias starts.
+    """
+    _, _, _, recorded_titles, recorded_runs, recorded_parse_calls, recorded_collapse_calls = _install_driver_run_mocks(
+        monkeypatch,
+        tmp_path,
+        two_steps_optimization=True,
+        autosomes_in_step_2=True,
+    )
+
+    run_tracts("driver.yaml", script_dir=tmp_path)
+    captured = capsys.readouterr()
+
+    assert "Starting parameters for step 1 optimization" in captured.out
+    assert "non-sex-bias parameters are fixed to the best step 1 estimates" in captured.out
+    assert recorded_titles == [
+        "Starting parameters for step 1 optimization",
+        "Starting parameters for step 2 optimization (non-sex-bias parameters are fixed to the best step 1 estimates)."
+        ]
+
+    assert [call["steps"] for call in recorded_runs] == [[1], [2]]
+    assert recorded_parse_calls == [
+        {
+            "sample_param_names": {"t", "rate_eur"},
+            "fixed_param_values": {"sb_eur": 0.0, "sb_afr": 0.0},
+        },
+        {
+            "sample_param_names": {"sb_eur", "sb_afr"},
+            "fixed_param_values": {"t": 11.0, "rate_eur": 22.0},
+        },
+    ]
+    assert [call["step_label"] for call in recorded_collapse_calls] == ["step 1", "step 2"]
+    _assert_arrays_list_equal(
+        recorded_runs[0]["start_params_list"],
+        [
+            np.array([1.0, 2.0, 0.0, 0.0]),
+            np.array([10.0, 20.0, 0.0, 0.0]),
+        ],
+    )
+    _assert_arrays_list_equal(
+        recorded_runs[1]["start_params_list"],
+        [
+            np.array([11.0, 22.0, 3.0, 4.0]),
+            np.array([11.0, 22.0, 30.0, 40.0]),
+        ],
+    )
+
+
+def test_run_tracts_forwards_autosomes_in_step_2_flag(tmp_path, monkeypatch):
+    """
+    Verify that the driver forwards autosomes_in_step_2 to the Step 2 optimization call.
+    """
+    _, _, _, _, recorded_runs, _, _ = _install_driver_run_mocks(
+        monkeypatch,
+        tmp_path,
+        two_steps_optimization=True,
+        autosomes_in_step_2=False,
+    )
+
+    run_tracts("driver.yaml", script_dir=tmp_path)
+
+    assert recorded_runs[0]["steps"] == [1]
+    assert recorded_runs[1]["steps"] == [2]
+    assert recorded_runs[1]["autosomes_in_step_2"] is False

--- a/tracts/core.py
+++ b/tracts/core.py
@@ -21,7 +21,7 @@ _min_out_of_bounds_val = -1e-10
 def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_func: callable, parameter_handler: FixedParametersHandler, outofbounds_fun:callable=None, 
                             verbose_log:int=0, verbose_screen:int=10, p_dict:dict=None, exclude_tracts_below_cM:float=0, 
                             maxiter:int=None, reset_counter:bool=True, ad_model_autosomes:str='DC',
-                            ad_model_allosomes:str='DC', npts:int=50) -> tuple[np.ndarray, float]:
+                            ad_model_allosomes:str='DC', npts:int=50, print_step_header:bool=True) -> tuple[np.ndarray, float]:
     """
     Optimizes the log-likelihood over all parameters defined by the demographic model, given a specified pair of admixture models for autosomes and allosomes.
     The optimization is carried out jointly in a single step, estimating all parameters simultaneously using both autosomal and allosomal data.
@@ -57,6 +57,11 @@ def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_f
         The model to use for allosomal admixture. Must be one of 'DC', 'DF', 'H-DC' or 'H-DF'. Default is 'DC'. If None, allosomal admixture will not be modeled.
     npts: int, optional
         Number of bins for the tract length histogram. Default is 50.
+    print_step_header: bool, optional
+        If True, print the admixture-model title and parameter-set subtitle at the start of the
+        optimization. If False, only the iteration table header is printed. For internal use only;
+        set automatically by :func:`~tracts.driver.run_model_multi_init` to suppress repeated
+        headers across multiple runs within the same step. Default is True.
 
     Returns
     -------
@@ -67,47 +72,42 @@ def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_f
     if reset_counter:
         global _counter
         _counter = 0
-    
-    # Load and process autosome data
-    autosome_bins, autosome_data = population.get_global_tractlengths(npts=npts,
-                                                                    exclude_tracts_below_cM=exclude_tracts_below_cM) 
+
+    autosome_bins, autosome_data = population.get_global_tractlengths(
+        npts=npts,
+        exclude_tracts_below_cM=exclude_tracts_below_cM,
+    )
     n_autosome_bins = len(autosome_bins)
     autosome_data_mapped = [np.zeros(n_autosome_bins, dtype='int64').tolist() for _i in dict(p_dict).keys()]
     for k, v in autosome_data.items():
         autosome_data_mapped[dict(p_dict)[k]] = v
-    
-    if ad_model_allosomes is not None: # Include allosome data for inference
-        
-        # Load and process allosome data
-        allosome_bins, allosome_data = population.get_global_allosome_tractlengths(allosome='X',
-                                                                                npts=npts,
-                                                                                exclude_tracts_below_cM=exclude_tracts_below_cM)
+
+    if ad_model_allosomes is not None:
+        allosome_bins, allosome_data = population.get_global_allosome_tractlengths(
+            allosome='X',
+            npts=npts,
+            exclude_tracts_below_cM=exclude_tracts_below_cM,
+        )
         n_allosome_bins = len(allosome_bins)
         allosome_length = population.allosome_lengths['X']
         female_data = allosome_data[SexType.FEMALE]
         male_data = allosome_data[SexType.MALE]
         num_males = population.num_males
         num_females = population.num_females
-        
-        # Allosome female data
-        female_data_mapped = [np.zeros(n_allosome_bins, dtype='int64').tolist()  for _i in dict(p_dict).keys()]
+
+        female_data_mapped = [np.zeros(n_allosome_bins, dtype='int64').tolist() for _i in dict(p_dict).keys()]
         for k, v in female_data.items():
             female_data_mapped[dict(p_dict)[k]] = v
-        
-        # Allosome male data
-        male_data_mapped = [np.zeros(n_allosome_bins, dtype='int64').tolist()  for _i in dict(p_dict).keys()]
+
+        male_data_mapped = [np.zeros(n_allosome_bins, dtype='int64').tolist() for _i in dict(p_dict).keys()]
         for k, v in male_data.items():
             male_data_mapped[dict(p_dict)[k]] = v
-    
-    local_parameter_handler = copy.deepcopy(parameter_handler) # Extract parameter_handler to modify it locally for optimization.
 
-    # ------------ Define objective function for optimization ------------
-
+    local_parameter_handler = copy.deepcopy(parameter_handler)
     best_objective = np.inf
     best_full_params = None
 
-    def objective_function(parameters): # parameters are in optimizer space
-
+    def objective_function(parameters):
         nonlocal best_objective, best_full_params
 
         global _counter
@@ -115,45 +115,45 @@ def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_f
         global _min_out_of_bounds_val
         _counter += 1
 
-        def flush_result(result, note = str()): 
-            param_str = 'ocsb: array([%s])' % (', '.join(['%- 12g' % v for v in parameter_handler.convert_to_physical_params(parameters)]))
-            if (verbose_log > 0) and (_counter % verbose_log == 0): # Adds iterations to log file
-                logger.info(
-                     "iter=%-6d | obj=%-12g | params=%s %s",
-                        _counter,
-                        result,
-                        param_str,
-                        note,
-                    )
-            if (verbose_screen > 0) and (_counter % verbose_screen == 0): # Prints iterations on screen
+        def flush_result(result, note=str()):
+            prev_time_param_logging = parameter_handler.enable_time_param_logging
+            parameter_handler.enable_time_param_logging = False
+            try:
+                param_str = 'ocsb: array([%s])' % (', '.join(['%- 12g' % v for v in parameter_handler.convert_to_physical_params(parameters, report_non_admissible=False)]))
+            finally:
+                parameter_handler.enable_time_param_logging = prev_time_param_logging
+            if (verbose_log > 0) and (_counter % verbose_log == 0):
+                logger.info("iter=%-6d | obj=%-12g | params=%s %s", _counter, result, param_str, note)
+            if (verbose_screen > 0) and (_counter % verbose_screen == 0):
                 eprint('%-8i, %-12g, %s, %s' % (_counter, result, param_str, note))
-                
-        if outofbounds_fun is not None: # outofbounds can return either True or a negative value to signify out-of-boundedness.
+
+        if outofbounds_fun is not None:
             oob = outofbounds_fun(parameters)
             if oob < 0:
-                out = oob * _out_of_bounds_val-_min_out_of_bounds_val
+                out = oob * _out_of_bounds_val - _min_out_of_bounds_val
                 flush_result(out, f'OOB (oob={oob})')
                 return out
         else:
             eprint("No bound function defined")
 
         matrices = model_func(parameters)
+
         matrix_list = [matrix for matrix in matrices.values()]
         if ad_model_allosomes is not None:
             [male_matrix, female_matrix] = matrix_list
         else:
-            male_matrix = matrix_list[0]  # Unbiased migration
-            female_matrix = matrix_list[0] 
+            male_matrix = matrix_list[0]
+            female_matrix = matrix_list[0]
 
-        # Model for autosomes
         if ad_model_autosomes == 'M':
-            model = PhTMonoecious(migration_matrix=0.5*(female_matrix+male_matrix),
-                                rho=1)
-            result_autosomes = model.loglik(bins=autosome_bins,
-                                        Ls=population.Ls,
-                                        data=[mat for mat in autosome_data_mapped],
-                                        num_samples=len(population.indivs),
-                                        cutoff=0)
+            model = PhTMonoecious(migration_matrix=0.5 * (female_matrix + male_matrix), rho=1)
+            result_autosomes = model.loglik(
+                bins=autosome_bins,
+                Ls=population.Ls,
+                data=[mat for mat in autosome_data_mapped],
+                num_samples=len(population.indivs),
+                cutoff=0,
+            )
         elif ad_model_autosomes == 'H-DC':
             result_autosomes=HP.HP_loglik(mig_matrix_f=female_matrix,
                                         mig_matrix_m=male_matrix,
@@ -293,16 +293,14 @@ def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_f
     # ------------ Define reduced objective function and out-of-bounds function for optimization ------------
 
     def reduced_objective_function(free_parameters_opt):
-
         extended_parameters = local_parameter_handler.extend_parameters(free_parameters=free_parameters_opt,
                                                                         units="opt",
-                                                                        counter=_counter, 
+                                                                        counter=_counter,
                                                                         verbose_warning_log=verbose_log) # NOTE: Add verbose_warning_screen=verbose_screen if RuntimeWarnings should be printed on screen.
         
         return objective_function(extended_parameters) #Full parameters in optimizer space
   
     def reduced_outofbounds_fun(free_parameters_opt):
-
         return outofbounds_fun(local_parameter_handler.extend_parameters(free_parameters=free_parameters_opt,
                                                                         units="opt")) #Full parameters in optimizer space
 
@@ -310,29 +308,32 @@ def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_f
 
     # ------------ Run single-step optimization ------------
 
-    if ad_model_allosomes is not None:
-        title_message = f"Admixture is modelled with the {ad_model_autosomes} model for autosomes and with the {ad_model_allosomes} model for allosomes."
-    else:
-        title_message = f"Admixture is modelled with the {ad_model_autosomes} model for autosomes."
-    subtitle_message = f"Optimizing model likelihood over parameters {str(local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices))}."
+    subtitle_message = (
+        "Optimizing model likelihood over parameters "
+        f"{str(local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices))}."
+    )
     subsubtitle_message = "Iter.\t Log-likelihood\t Model parameters\t Transmission"
-    
-    line = "-" * len(title_message)
-    print('\n' + line)
-    print(title_message)
-    print(line)
+    line = "-" * len(subsubtitle_message)
+
+    if print_step_header:
+        print(subtitle_message)
+        logger.info(subtitle_message)
 
     if (verbose_log > 0) and (_counter % verbose_log == 0):
-        for l in [subtitle_message, line, subsubtitle_message, line]:
+        for l in [subsubtitle_message, line]:
             logger.info(l)
     if (verbose_screen > 0) and (_counter % verbose_screen == 0):
-        for l in [subtitle_message, line, subsubtitle_message, line]:
+        for l in [subsubtitle_message, line]:
             print(l)
 
     reduced_objective_to_optimize = lambda x: reduced_objective_function(x)
 
-    outputs = scipy.optimize.fmin_cobyla(
-        reduced_objective_to_optimize, reduced_p0, reduced_outofbounds_fun, rhobeg=.01, rhoend=.0001, maxfun=maxiter)
+    outputs = scipy.optimize.fmin_cobyla(func=reduced_objective_to_optimize,
+                                        x0=reduced_p0,
+                                        cons=reduced_outofbounds_fun,
+                                        rhobeg=.01,
+                                        rhoend=.0001,
+                                        maxfun=maxiter)
     
     optimized_parameters = local_parameter_handler.extend_parameters(free_parameters=outputs,
                                                                     units="opt",
@@ -353,11 +354,17 @@ def optimize_cob_sex_biased_single_step(p0:list, population: Population, model_f
 def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_func:callable, parameter_handler: FixedParametersHandler,
                                     outofbounds_fun:callable=None, verbose_log:int=0, verbose_screen:int=10,
                                     p_dict:dict=None, exclude_tracts_below_cM:float=0, maxiter:int=None, reset_counter:bool=True, 
-                                    ad_model_autosomes:str='DC', ad_model_allosomes:str='DC', npts:int=50) -> tuple[np.ndarray, float]:
+                                    ad_model_autosomes:str='DC', ad_model_allosomes:str='DC', autosomes_in_step_2:bool=True, steps: list[int | str] | None = None, npts:int=50, print_step_header:bool=True,
+                                    return_full_likelihood: bool = False) -> tuple[np.ndarray, float] | tuple[np.ndarray, float, float | None]:
     """
     Optimizes the log-likelihood over all parameters defined by the demographic model, for a specified admixture model applied to both autosomes and allosomes.
-    The procedure is carried out in two steps: first, the non–sex-bias parameters are estimated by maximizing the log-likelihood using autosomal data only.
-    Second, the sex-bias parameters are estimated using both autosomal and allosomal data.
+    The procedure supports exactly three modes.
+
+    1. Step 1 only: optimize only non-sex-bias parameters using autosomal data.
+    2. Step 2 only: fix non-sex-bias parameters at their ``p0`` values and optimize only sex-bias parameters using allosomal data, optionally together with autosomal data if ``autosomes_in_step_2`` is True.
+    3. Step 1 + Step 2: first run step 1, then fix non-sex-bias parameters at their step-1 estimates and optimize only sex-bias parameters as in step 2.
+
+    No other optimization-step combinations are allowed.
 
     Parameters
     ----------    
@@ -389,20 +396,80 @@ def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_fun
     ad_model_autosomes: str, optional
         The model to use for autosomal admixture. Must be one of 'DC', 'DF', 'M', 'H-DC' or 'H-DF'. Default is 'DC'.
     ad_model_allosomes: str, optional
-        The model to use for allosomal admixture. Must be one of 'DC', 'DF', 'H-DC' or 'H-DF'. Default is 'DC'. If None, allosomal admixture will not be modeled.
+        The model to use for allosomal admixture. Must be one of 'DC', 'DF', 'H-DC' or 'H-DF'. Default is 'DC'.
+        If None (no allosomal data provided), step 2 cannot be run. If only step 2 is requested (steps=[2]), an error is raised.
+        If both steps are requested (steps=None or steps=[1,2]), step 2 is automatically disabled with a log message.
+    autosomes_in_step_2: bool, optional
+        If True, both autosomal and allosomal data will be used in the second optimization step. If False, only allosomal data will be used.
+        This option is only relevant when step 2 is run. Default is True.
+    steps: list[int | str] | None, optional
+        A list specifying which steps to run. Step 1 (non-sex-bias parameter optimization) can be denoted as 1 or 'step1', and step 2 (sex-bias parameter optimization)
+        can be denoted as 2 or 'step2'. The only allowed combinations are step 1 only, step 2 only, or both steps.
+        Examples of valid values are [1], ['step1'], [2], ['step2'], [1, 2], or ['step1', 'step2'].
+        Mixed types are allowed, but duplicate references to the same step such as [1, 'step1'] are not. Default is None (both steps will be run).
     npts: int, optional
         Number of bins for the tract length histogram. Default is 50.
+    print_step_header: bool, optional
+        If True, print the admixture-model title and step subtitle at the start of each optimization
+        step. If False, only the iteration table header is printed. For internal use only; set
+        automatically by :func:`~tracts.driver.run_model_multi_init` to suppress repeated headers
+        across multiple runs within the same step. Default is True.
 
     Returns
     -------
-    tuple [np.ndarray, float]
-        A tuple containing the optimal parameters found and the corresponding likelihood.
+    tuple [np.ndarray, float] or tuple [np.ndarray, float, float | None]
+        By default, returns the optimal parameters found and the optimization likelihood.
+        If ``return_full_likelihood`` is True, also returns an additional full-data
+        likelihood. The additional likelihood is only non-None when step 2 is run
+        with allosomal data only (``autosomes_in_step_2=False``), and corresponds
+        to evaluating the final parameters on autosomal + allosomal data.
     """
+
+    def _format_return(parameters: np.ndarray, likelihood: float, full_likelihood: float | None = None):
+        if return_full_likelihood:
+            return parameters, likelihood, full_likelihood
+        return parameters, likelihood
 
     if reset_counter:
         global _counter
         _counter = 0
-    
+
+    # ----------- Specify which steps are to be run in the optimization procedure ------------
+
+    if steps is not None: # Validate steps argument
+        if not isinstance(steps, list):
+            raise TypeError("steps must be a list of integers or strings, or None.")
+        valid_step_values = {1, 2, 'step1', 'step2'}
+        for step in steps:
+            if step not in valid_step_values:
+                raise ValueError(f"Invalid step value: {step}. Must be one of {valid_step_values}.")
+        if len(steps) == 0:
+            raise ValueError("steps list cannot be empty.")
+
+    if steps is None:
+        normalized_steps = (1, 2)
+    else:
+        normalized_steps = tuple(sorted({1 if step in (1, 'step1') else 2 for step in steps}))
+        if len(normalized_steps) != len(steps):
+            raise ValueError("steps cannot contain duplicate references to the same optimization step.")
+        if normalized_steps not in ((1,), (2,), (1, 2)):
+            raise ValueError("Only step 1 only, step 2 only, or the combined step 1 + step 2 optimization are allowed.")
+
+    step_1 = 1 in normalized_steps
+    step_2 = 2 in normalized_steps
+
+    if ad_model_allosomes is None and step_2:
+        if step_1:
+            # Both steps were requested, but allosomes unavailable - downgrade to step 1 only
+            logger.info("ad_model_allosomes is None (no allosomal data provided). Forcing step 2 to False and running only step 1.")
+            step_2 = False
+        else:
+            # Step 2 only was explicitly requested, but allosomes unavailable - error
+            raise ValueError("ad_model_allosomes is None but step 2 only was explicitly requested. Step 2 requires allosomal data. Please specify steps=[1] or steps=None to run step 1 only or both steps respectively.")
+
+    # ----------- Load data and map to model populations ------------
+
+    # Include autosomal data for inference
     autosome_bins, autosome_data = population.get_global_tractlengths(npts=npts, exclude_tracts_below_cM=exclude_tracts_below_cM) 
     n_autosome_bins = len(autosome_bins)
 
@@ -410,7 +477,7 @@ def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_fun
     for k, v in autosome_data.items():
         autosome_data_mapped[dict(p_dict)[k]] = v
     
-    if ad_model_allosomes is not None: # Include allosomal data for inference
+    if ad_model_allosomes is not None and step_2: # Include allosomal data for inference at step 2
 
         allosome_bins, allosome_data = population.get_global_allosome_tractlengths('X', npts=npts, exclude_tracts_below_cM=exclude_tracts_below_cM)
         n_allosome_bins = len(allosome_bins)
@@ -428,23 +495,38 @@ def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_fun
         for k, v in male_data.items():
             male_data_mapped[dict(p_dict)[k]] = v
 
-    # ------------ Fix free sex-biased parameters for the first optimization step ------------
+    # ------------ Set up fixed parameters for the upcoming optimization step ------------
+
+    best_objective = np.inf
+    best_full_params = None
 
     local_parameter_handler = copy.deepcopy(parameter_handler)
 
+    # Identify free sex-bias parameters
     free_sex_bias_parameters = {param:0 for param, value in local_parameter_handler.demography.model_base_params.items() if 
                                 (value.type == ParamType.SEX_BIAS) and 
                                 (param not in local_parameter_handler.user_params_fixed_by_value) and 
                                 (param not in local_parameter_handler.params_fixed_by_ancestry)}
 
-    local_parameter_handler.add_fixed_parameters(free_sex_bias_parameters)
-    
-    best_objective = np.inf
-    best_full_params = None
-
+    if step_1:
+        # Fix free sex-bias parameters for step 1 optimization (optimize non-sex-bias parameters)
+        local_parameter_handler.add_fixed_parameters(free_sex_bias_parameters)
+    else:
+        # Step 2 only: fix non-sex-bias parameters at p0 values (optimize only sex-bias parameters)
+        param_names_ordered = list(local_parameter_handler.demography.model_base_params.keys())
+        fixed_non_sex_bias = {}
+        for idx, param_name in enumerate(param_names_ordered):
+            param_info = local_parameter_handler.demography.model_base_params[param_name]
+            if (param_info.type != ParamType.SEX_BIAS and 
+                param_name not in local_parameter_handler.user_params_fixed_by_value and
+                param_name not in local_parameter_handler.params_fixed_by_ancestry):
+                if idx < len(p0):
+                    fixed_non_sex_bias[param_name] = p0[idx]
+        local_parameter_handler.add_fixed_parameters(fixed_non_sex_bias)
+        
     # ----------- Define objective function for optimization ------------
 
-    def objective_function(model_base_parameters, include_allosomes = True): # parameters are in optimizer space
+    def objective_function(model_base_parameters, include_autosomes = True, include_allosomes = True): # parameters are in optimizer space
 
         nonlocal best_objective, best_full_params
 
@@ -453,8 +535,16 @@ def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_fun
         global _min_out_of_bounds_val
         _counter += 1
 
+        if not include_autosomes and not include_allosomes:
+            raise ValueError("At least one of include_autosomes or include_allosomes must be True.")
+
         def flush_result(result, note = str()):
-            param_str = 'array([%s])' % (', '.join(['%- 12g' % v for v in local_parameter_handler.convert_to_physical_params(model_base_parameters)]))
+            prev_time_param_logging = local_parameter_handler.enable_time_param_logging
+            local_parameter_handler.enable_time_param_logging = False
+            try:
+                param_str = 'array([%s])' % (', '.join(['%- 12g' % v for v in local_parameter_handler.convert_to_physical_params(model_base_parameters, report_non_admissible=False)]))
+            finally:
+                local_parameter_handler.enable_time_param_logging = prev_time_param_logging
             if (verbose_log > 0) and (_counter % verbose_log == 0): # Add iteration to log file
                 logger.info(
                      "iter=%-6d | obj=%-12g | params=%s %s",
@@ -484,54 +574,55 @@ def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_fun
             male_matrix = matrix_list[0]  # Unbiased migration
             female_matrix = matrix_list[0]  # Unbiased migration
 
-
-        # Model for autosomes
-        if ad_model_autosomes == 'M':
-            model = PhTMonoecious(migration_matrix=0.5*(female_matrix+male_matrix),
-                                rho=1)
-            result_autosomes = model.loglik(bins=autosome_bins,
-                                            Ls=population.Ls,
-                                            data=[mat for mat in autosome_data_mapped],
-                                            num_samples=len(population.indivs))
-        elif ad_model_autosomes == 'H-DC':
-            result_autosomes=HP.HP_loglik(mig_matrix_f=female_matrix,
-                                        mig_matrix_m=male_matrix,
-                                        rho_f=1,
-                                        rho_m=1,
-                                        TP = 2,
-                                        Dioecious_model = 'DC',
-                                        X_chr = False,
-                                        X_chr_male = False,
-                                        N_cores = 5,
-                                        bins=autosome_bins,
-                                        Ls=population.Ls,
-                                        data=[mat for mat in autosome_data_mapped],
-                                        num_samples=len(population.indivs), cutoff=0)
-        elif ad_model_autosomes == 'H-DF':
-            result_autosomes=HP.HP_loglik(mig_matrix_f=female_matrix,
-                                        mig_matrix_m=male_matrix,
-                                        rho_f=1,
-                                        rho_m=1,
-                                        TP = 2,
-                                        Dioecious_model = 'DF',
-                                        X_chr = False,
-                                        X_chr_male = False,
-                                        N_cores = 5,
-                                        bins=autosome_bins,
-                                        Ls=population.Ls,
-                                        data=[mat for mat in autosome_data_mapped],
-                                        num_samples=len(population.indivs), cutoff=0)
-        else:
-            assert male_matrix.shape[0] < 20, "PhTDioecious currently only supports less than 20 generations for autosomes."
-            result_autosomes = PhTDioecious(migration_matrix_f=female_matrix,
-                                            migration_matrix_m=male_matrix,
+        if include_autosomes: # Model for autosomes
+            
+            if ad_model_autosomes == 'M':
+                model = PhTMonoecious(migration_matrix=0.5*(female_matrix+male_matrix),
+                                    rho=1)
+                result_autosomes = model.loglik(bins=autosome_bins,
+                                                Ls=population.Ls,
+                                                data=[mat for mat in autosome_data_mapped],
+                                                num_samples=len(population.indivs))
+            elif ad_model_autosomes == 'H-DC':
+                result_autosomes=HP.HP_loglik(mig_matrix_f=female_matrix,
+                                            mig_matrix_m=male_matrix,
                                             rho_f=1,
                                             rho_m=1,
-                                            sex_model=ad_model_autosomes).loglik(bins=autosome_bins,
-                                                                                Ls=population.Ls,
-                                                                                data=[mat for mat in autosome_data_mapped],
-                                                                                num_samples=len(population.indivs))
-        
+                                            TP = 2,
+                                            Dioecious_model = 'DC',
+                                            X_chr = False,
+                                            X_chr_male = False,
+                                            N_cores = 5,
+                                            bins=autosome_bins,
+                                            Ls=population.Ls,
+                                            data=[mat for mat in autosome_data_mapped],
+                                            num_samples=len(population.indivs), cutoff=0)
+            elif ad_model_autosomes == 'H-DF':
+                result_autosomes=HP.HP_loglik(mig_matrix_f=female_matrix,
+                                            mig_matrix_m=male_matrix,
+                                            rho_f=1,
+                                            rho_m=1,
+                                            TP = 2,
+                                            Dioecious_model = 'DF',
+                                            X_chr = False,
+                                            X_chr_male = False,
+                                            N_cores = 5,
+                                            bins=autosome_bins,
+                                            Ls=population.Ls,
+                                            data=[mat for mat in autosome_data_mapped],
+                                            num_samples=len(population.indivs), cutoff=0)
+            else:
+                assert male_matrix.shape[0] < 20, "PhTDioecious currently only supports less than 20 generations for autosomes."
+                result_autosomes = PhTDioecious(migration_matrix_f=female_matrix,
+                                                migration_matrix_m=male_matrix,
+                                                rho_f=1,
+                                                rho_m=1,
+                                                sex_model=ad_model_autosomes).loglik(bins=autosome_bins,
+                                                                                    Ls=population.Ls,
+                                                                                    data=[mat for mat in autosome_data_mapped],
+                                                                                    num_samples=len(population.indivs))
+            flush_result(result_autosomes, 'Autosomes')
+
         if include_allosomes: # Model for allosomes
             
             if ad_model_allosomes == 'H-DC':
@@ -613,140 +704,194 @@ def optimize_cob_sex_biased_two_steps(p0:list, population: Population, model_fun
                                                                         data=[mat for mat in male_data_mapped],
                                                                         num_samples=num_males)
 
-            result = (result_autosomes + result_X_females + result_X_males)
             flush_result(result_X_females, 'Female allosomes')
             flush_result(result_X_males, 'Male allosomes')
-        else:
-            result = result_autosomes
         
-        flush_result(result_autosomes, 'Autosomes')
+        
+        if include_autosomes and include_allosomes:
+            result = result_autosomes + result_X_females + result_X_males
+        elif include_autosomes and not include_allosomes:
+            result = result_autosomes
+        elif not include_autosomes and include_allosomes:
+            result = result_X_females + result_X_males
+        else:
+            raise ValueError("At least one of include_autosomes or include_allosomes must be True.")        
         
         obj = -result
 
-        if include_allosomes and np.isfinite(obj) and obj < best_objective:
+        if np.isfinite(obj) and obj < best_objective:
             best_objective = obj
             best_full_params = model_base_parameters.copy()
         return obj
 
-    # ------------ Define reduced objective function and out-of-bounds function for optimization ------------
+    # Reduced functions are shared by both optimization steps
 
-    def reduced_objective_function(free_parameters_opt, include_allosomes = True):
-
-        extended_parameters = local_parameter_handler.extend_parameters(free_parameters=free_parameters_opt,
+    def reduced_objective_function(free_parameters_opt, include_autosomes=True, include_allosomes=True):
+        extended_parameters = local_parameter_handler.extend_parameters(free_parameters=free_parameters_opt,  # Full parameters in optimizer space
                                                                         units="opt",
-                                                                        counter=_counter, 
+                                                                        counter=_counter,
                                                                         verbose_warning_log=verbose_log) # NOTE: Add verbose_warning_screen=verbose_screen if RuntimeWarnings should be printed on screen.
-        
-        return objective_function(extended_parameters, include_allosomes=include_allosomes) #Full parameters in optimizer space
-  
+
+        return objective_function(model_base_parameters=extended_parameters,
+                                  include_autosomes=include_autosomes,
+                                  include_allosomes=include_allosomes) 
+
     def reduced_outofbounds_fun(free_parameters_opt):
+        return outofbounds_fun(local_parameter_handler.extend_parameters(free_parameters=free_parameters_opt, # Full parameters in optimizer space
+                                                                        units="opt"))
 
-        return outofbounds_fun(local_parameter_handler.extend_parameters(free_parameters=free_parameters_opt,
-                                                                        units="opt")) #Full parameters in optimizer space
-
-    reduced_p0 = local_parameter_handler.reduce_parameters(p0) # Initial parameters
-
-    # ------------ Run first optimization step on autosomal data ------------
-
-    if ad_model_allosomes is not None:
-        title_message = f"Admixture is modelled with the {ad_model_autosomes} model for autosomes and with the {ad_model_allosomes} model for allosomes."
-        subtitle_message = f"Optimization is performed in two steps.\nStep 1 : Optimizing autosomal likelihood over parameters {str(local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices))}."
-    else:
-        title_message = f"Admixture is modelled with the {ad_model_autosomes} model for autosomes."
-        subtitle_message = f"Optimizing autosomal likelihood over parameters {str(local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices))}."
-    
-    line = "-" * len(title_message)
-    
-    for l in [line, title_message, subtitle_message]:
-        logger.info(l)
-        print(l)
-    
     table_header = "Iter.\t Log-likelihood\t Model parameters\t Transmission"
-    for l in [table_header, line]:
-        if verbose_log>0:
-            logger.info(l)
-        if verbose_screen>0:
-            print(l)
+    line_header = "-" * len(table_header.expandtabs())
+
+    if step_1:
+    
+        reduced_p0 = local_parameter_handler.reduce_parameters(p0) # Initial parameters
+
+        # ------------ Run first optimization step on autosomal data across non-sex-bias parameters ------------
+
+        if ad_model_allosomes is not None and step_2:
+            subtitle_message = f"Optimization is performed in two steps.\nStep 1 : Optimizing autosomal likelihood over parameters {str(local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices))}."
+        else:
+            subtitle_message = f"Step 1 : Optimizing autosomal likelihood over parameters {str(local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices))}."      
+
+        if print_step_header:
+            print(subtitle_message)
+            logger.info(subtitle_message)
+
+        for l in [table_header, line_header]:
+            if verbose_log>0:
+                logger.info(l)
+            if verbose_screen>0:
+                print(l)
             
-    reduced_objective_autosomes = lambda x: reduced_objective_function(x, include_allosomes = False)
+        reduced_objective_autosomes = lambda x: reduced_objective_function(x, include_allosomes=False)
     
-    outputs = scipy.optimize.fmin_cobyla(
-        reduced_objective_autosomes, reduced_p0, reduced_outofbounds_fun, rhobeg=.01, rhoend=.0001, maxfun=maxiter)
+        outputs = scipy.optimize.fmin_cobyla(func=reduced_objective_autosomes,
+                                            x0=reduced_p0,
+                                            cons=reduced_outofbounds_fun,
+                                            rhobeg=.01,
+                                            rhoend=.0001,
+                                            maxfun=maxiter)
     
-    optimized_parameters = local_parameter_handler.extend_parameters(free_parameters=outputs,
-                                                                    units="opt",
-                                                                    show_ancestry_warning=True)
-    step1_full_params_opt = optimized_parameters.copy()
+        optimized_parameters = local_parameter_handler.extend_parameters(free_parameters=outputs,
+                                                                        units="opt",
+                                                                        show_ancestry_warning=True)
+        final_message = f"Optimization completed"
 
-    # ------------ Run second optimization step on autosomal and allosomal data ------------
+    if step_2:
+    
+        # ------------ Run second optimization step on sex-bias parameters ------------
+        
+        if not step_1:
+            # Step 2 only: optimized_parameters starts at p0, non-sex-bias already fixed, sex-bias already free
+            optimized_parameters = np.array(p0)
+        else:
+            # Step 1 ran: release sex-bias parameters and fix optimized non-sex-bias parameters
+            new_fixed_parameters_names = local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices)
+            new_fixed_values = optimized_parameters[local_parameter_handler.free_parameters_indices]
+            new_fixed_parameters = dict(zip(new_fixed_parameters_names, new_fixed_values))
+            local_parameter_handler.release_fixed_parameters(free_sex_bias_parameters.keys())
+            local_parameter_handler.add_fixed_parameters(new_fixed_parameters)
 
-    new_fixed_parameters_names = local_parameter_handler.indices_to_labels(local_parameter_handler.free_parameters_indices)
-    new_fixed_values = optimized_parameters[local_parameter_handler.free_parameters_indices]
-    new_fixed_parameters = dict(zip(new_fixed_parameters_names, new_fixed_values))
+        reduced_params = local_parameter_handler.reduce_parameters(optimized_parameters)
 
-    local_parameter_handler.release_fixed_parameters(free_sex_bias_parameters.keys())
-
-    local_parameter_handler.add_fixed_parameters(new_fixed_parameters)
-    reduced_params = local_parameter_handler.reduce_parameters(optimized_parameters)
-
-    if ad_model_allosomes is not None:
-        print('Step 1 completed.')
-        step_2_message_1 = f"Step 2 : Optimizing autosomal + allosomal likelihood over parameters : {str(list(free_sex_bias_parameters.keys()))}."
-        step_2_message = f"{step_2_message_1}\nNon-sex-bias parameters fixed at values from previous optimization step."    
+        step_2_data = "autosomal + allosomal" if autosomes_in_step_2 else "allosomal"            
+        step_2_message_1 = f"Step 2 : Optimizing {step_2_data} likelihood over parameters : {str(list(free_sex_bias_parameters.keys()))}."
+        step_2_message = f"{step_2_message_1}\nNon-sex-bias parameters fixed at initial values." if not step_1 else f"{step_2_message_1}\nNon-sex-bias parameters fixed at values from previous optimization step."    
         line = "-" * len(step_2_message_1)
-    else:
-        step_2_message = f"Optimization completed."   
-        line = "-" * len(step_2_message)
     
-    if len(reduced_params)>0 and verbose_log>0:
-        logger.info(line)
-        logger.info(step_2_message)
-        if ad_model_allosomes is not None:    
-            logger.info('Iter.\t Log-likelihood\t Model parameters\t Transmission')
-            logger.info(line)
-    if len(reduced_params)>0 and verbose_screen>0:
-        print(line)
-        print(step_2_message)
-        if ad_model_allosomes is not None:
-            print('Iter.\t Log-likelihood\t Model parameters\t Transmission')
-            print(line)
+        if len(reduced_params)>0 and verbose_log>0:
+            if print_step_header:
+                logger.info(line)
+                logger.info(step_2_message)
+            if ad_model_allosomes is not None:    
+                logger.info(table_header)
+                logger.info(line_header)
+        if len(reduced_params)>0 and verbose_screen>0:
+            if print_step_header:
+                print(line)
+                print(step_2_message)
+            if ad_model_allosomes is not None:
+                print(table_header)
+                print(line_header)
 
-    best_objective = np.inf
-    best_full_params = None
+        best_objective = np.inf
+        best_full_params = None
 
-    reduced_objective_autosomes = lambda x: reduced_objective_function(x, include_allosomes = True)
-    if len(reduced_params)>0 and ad_model_allosomes is not None:
-        outputs = scipy.optimize.fmin_cobyla(
-            reduced_objective_autosomes, reduced_params, reduced_outofbounds_fun, rhobeg=.01, rhoend=.0001, maxfun=maxiter)
-        print('Step 2 completed.')
-        _ = local_parameter_handler.extend_parameters(free_parameters=outputs,
-                                                                    units="opt",
-                                                                    show_ancestry_warning=True) # Checks for the ancestry warning at the end of step 2.
-        print(line)
-
-    else: # No optimization needed
-        end_message = f"No parameters to optimize in step 2. Optimization completed."
-        for l in [end_message, "-" * len(end_message)]:
-            print(l)
-            logger.info(l)
-        outputs = reduced_params
+        reduced_objective_allosomes = lambda x: reduced_objective_function(x, include_autosomes=autosomes_in_step_2, include_allosomes=True)
+        
+        if len(reduced_params)>0:
+            outputs = scipy.optimize.fmin_cobyla(func=reduced_objective_allosomes,
+                                                x0=reduced_params,
+                                                cons=reduced_outofbounds_fun,
+                                                rhobeg=.01,
+                                                rhoend=.0001,
+                                                maxfun=maxiter)
+            
+            step2_full_params_opt = local_parameter_handler.extend_parameters(free_parameters=outputs,
+                                                                               units="opt",
+                                                                               show_ancestry_warning=True) # Checks for the ancestry warning at the end of step 2.
     
+            final_message = f"Optimization completed."
+            line = "-" * len(final_message)
+            for l in [final_message, line]:
+                print(l)
+                logger.info(l)
+
+            # ------------ Return optimal parameters corresponding to best likelihood ------------
+            
+            if best_full_params is None:
+                try:
+                    fallback_likelihood = -objective_function(step2_full_params_opt, include_autosomes=autosomes_in_step_2, include_allosomes=True)
+                    full_data_likelihood = None
+                    if not autosomes_in_step_2:
+                        prev_best_objective = best_objective
+                        prev_best_full_params = best_full_params
+                        full_data_likelihood = -objective_function(step2_full_params_opt, include_autosomes=True, include_allosomes=True)
+                        best_objective = prev_best_objective
+                        best_full_params = prev_best_full_params
+                    return _format_return(step2_full_params_opt, fallback_likelihood, full_data_likelihood)
+                except Exception:
+                    return _format_return(step2_full_params_opt, -1e32, None)
+
+            full_data_likelihood = None
+            if not autosomes_in_step_2:
+                prev_best_objective = best_objective
+                prev_best_full_params = best_full_params
+                full_data_likelihood = -objective_function(best_full_params, include_autosomes=True, include_allosomes=True)
+                best_objective = prev_best_objective
+                best_full_params = prev_best_full_params
+            return _format_return(best_full_params, -best_objective, full_data_likelihood)
+        
+        else:
+            final_message = f"No free parameters to optimize at step 2. Optimization completed."
+
     # ------------ Return optimal parameters corresponding to best likelihood ------------
-
-    if len(reduced_params) == 0 and ad_model_allosomes is not None:
-        full_params_opt = optimized_parameters.copy()
-        likelihood = -objective_function(full_params_opt, include_allosomes=True)
-        return full_params_opt, likelihood
-    if ad_model_allosomes is None:
-        full_params_opt = optimized_parameters.copy()
-        likelihood = -objective_function(full_params_opt, include_allosomes=False)
-        return full_params_opt, likelihood
     
+    line = "-" * len(final_message)
+    for l in [final_message, line]:
+        print(l)
+        logger.info(l)
+            
     if best_full_params is None:
         try:
-            fallback_likelihood = -objective_function(step1_full_params_opt, include_allosomes=True)
-            return step1_full_params_opt, fallback_likelihood
+            if step_2:
+                fallback_likelihood = -objective_function(optimized_parameters,
+                                                          include_autosomes=autosomes_in_step_2,
+                                                          include_allosomes=True)
+                full_data_likelihood = None
+                if not autosomes_in_step_2:
+                    prev_best_objective = best_objective
+                    prev_best_full_params = best_full_params
+                    full_data_likelihood = -objective_function(optimized_parameters,
+                                                               include_autosomes=True,
+                                                               include_allosomes=True)
+                    best_objective = prev_best_objective
+                    best_full_params = prev_best_full_params
+                return _format_return(optimized_parameters, fallback_likelihood, full_data_likelihood)
+            else:
+                fallback_likelihood = -objective_function(optimized_parameters, include_allosomes=False)
+            return _format_return(optimized_parameters, fallback_likelihood, None)
         except Exception:
-            return step1_full_params_opt, -1e32
-
-    return best_full_params, -best_objective      
+            return _format_return(optimized_parameters, -1e32, None)
+    return _format_return(best_full_params, -best_objective, None)

--- a/tracts/demography/base_parametrized_demography.py
+++ b/tracts/demography/base_parametrized_demography.py
@@ -856,10 +856,18 @@ class FixedParametersHandler:
 
     def _get_time_param_state_key(self, param_name: str, max_time: float) -> tuple[str, float]:
         """
-        Build a stable key for warning state that survives handler deep copies
-        and deduplicates across model variants (e.g., autosomal/allosomal).
+        Build a stable key for warning state that survives handler deep copies and
+        deduplicates across model variants (e.g., autosomal/allosomal), but avoids
+        collisions between unrelated models by using a hash of the model's parameter schema.
         """
-        return param_name, float(max_time)
+        import hashlib
+        if self.demography is None:
+            model_sig = "unknown_demography"
+        else:
+            # Use parameter names and types for a stable signature
+            param_schema = tuple((k, getattr(v, 'type', None)) for k, v in self.demography.model_base_params.items())
+            model_sig = hashlib.sha256(repr(param_schema).encode('utf-8')).hexdigest()
+        return model_sig, param_name, float(max_time)
 
     @property
     def has_been_fixed(self):
@@ -902,6 +910,7 @@ class FixedParametersHandler:
             A list of parameter names for which to get the indices.
         
         Returns
+        
         -------
         np.ndarray
             An array of indices corresponding to the positions of the parameters in ``param_list`` as they appear in :py:attr:`~tracts.demography.base_parametrized_demography.BaseParametrizedDemography.model_base_params`.

--- a/tracts/demography/base_parametrized_demography.py
+++ b/tracts/demography/base_parametrized_demography.py
@@ -831,14 +831,15 @@ class FixedParametersHandler:
         A boolean that controls whether time admissibility warnings and state tracking are active.
     _time_param_admissibility_state: dict[str, bool]
         A dict mapping time parameter names to booleans indicating whether each time parameter is currently within admissible bounds. This is used to track transitions between admissible and non-admissible states for time parameters in order to emit warnings appropriately.
-    _shared_time_param_admissibility_state: dict[tuple[str, str, float], bool]
-        Process-global state shared across handler instances. Keys are ``(model_key, param_name, max_time)`` and values track the latest admissibility status; used to preserve transition tracking when handlers are deep-copied during optimization.
-    _shared_time_param_non_admissible_warned: set[tuple[str, str, float]]
-        Process-global latch indicating that the non-admissible warning has already been emitted for a given ``(model_key, param_name, max_time)`` key; used to avoid repeated warning spam across copied handlers.
+    _shared_time_param_admissibility_state: dict[tuple[str, float], bool]
+        Process-global state shared across handler instances. Keys are ``(param_name, max_time)`` and values track the latest admissibility status; used to preserve transition tracking when handlers are deep-copied during optimization.
+    _shared_time_param_non_admissible_warned: set[tuple[str, float]]
+        Process-global latch indicating that the non-admissible warning has already been emitted for a given ``(param_name, max_time)`` key; used to avoid repeated warning spam across copied handlers and across model variants.
     """
 
-    _shared_time_param_admissibility_state: dict[tuple[str, str, float], bool] = {} # Shared across handler instances so warnings are not re-emitted when handlers are deep-copied during optimization.
-    _shared_time_param_non_admissible_warned: set[tuple[str, str, float]] = set()
+    _shared_time_param_admissibility_state: dict[tuple[str, float], bool] = {} # Shared across handler instances so warnings are not re-emitted when handlers are deep-copied during optimization.
+    _shared_time_param_non_admissible_warned: set[tuple[str, float]] = set()
+    _shared_time_param_back_admissible_warned: set[tuple[str, float]] = set()
 
     def __init__(self, logger: logging.Logger):
         self.logger = logger
@@ -853,17 +854,12 @@ class FixedParametersHandler:
         self.enable_time_param_logging = True  # Controls whether time admissibility warnings/state tracking are active.
         self._time_param_admissibility_state: dict[str, bool] = {} # Tracks whether each time parameter is currently within admissible bounds.
 
-    def _get_time_param_state_key(self, param_name: str, max_time: float) -> tuple[str, str, float]:
+    def _get_time_param_state_key(self, param_name: str, max_time: float) -> tuple[str, float]:
         """
-        Build a stable key for warning state that survives handler deep copies.
+        Build a stable key for warning state that survives handler deep copies
+        and deduplicates across model variants (e.g., autosomal/allosomal).
         """
-        if self.demography is None:
-            model_key = "unknown_demography"
-        elif self.demography.name:
-            model_key = self.demography.name
-        else:
-            model_key = "|".join(self.demography.model_base_params.keys())
-        return model_key, param_name, float(max_time)
+        return param_name, float(max_time)
 
     @property
     def has_been_fixed(self):
@@ -969,6 +965,8 @@ class FixedParametersHandler:
                         self.logger.info(
                             f'In optimizer units: {optimizer_params[index]}, in physical units: {converted_params[index]}.')
                         self._shared_time_param_non_admissible_warned.add(state_key)
+                        # Clear back-admissible latch so the warning can fire again once the param recovers.
+                        self._shared_time_param_back_admissible_warned.discard(state_key)
                 elif previous_state and not is_admissible:
                     if not already_warned_non_admissible:
                         self.logger.warning(
@@ -976,9 +974,16 @@ class FixedParametersHandler:
                         self.logger.info(
                             f'In optimizer units: {optimizer_params[index]}, in physical units: {converted_params[index]}.')
                         self._shared_time_param_non_admissible_warned.add(state_key)
+                    # Clear back-admissible latch so the warning can fire again once the param recovers.
+                    self._shared_time_param_back_admissible_warned.discard(state_key)
                 elif (not previous_state) and is_admissible:
-                    self.logger.warning(
-                        f'Time parameter {param_name} is back in the admissible region (<= {max_time}).')
+                    already_warned_back_admissible = state_key in self._shared_time_param_back_admissible_warned
+                    if not already_warned_back_admissible:
+                        self.logger.warning(
+                            f'Time parameter {param_name} is back in the admissible region (<= {max_time}).')
+                        self._shared_time_param_back_admissible_warned.add(state_key)
+                    # Clear the non-admissible latch so a future non-admissible transition can warn again.
+                    self._shared_time_param_non_admissible_warned.discard(state_key)
 
                 # Optional reminder for end-of-optimization-step reporting.
                 if report_non_admissible and (not is_admissible) and previous_state is False:
@@ -1346,7 +1351,7 @@ class FixedParametersHandler:
 
         error = np.linalg.norm(param_objective_func(solved_params))
         if not np.isclose(error, 0):
-            ancestry_message = f"Could not solve for parameters fixed by ancestry proportions.\nFinal error: {error}, solved_params (physical) = {self.convert_to_physical_params(self.insert_solved_params(full_params=params_opt, param_values_from_proportions=solved_params))}.\nThis can happen when no sex bias parameter allows for the observed ancestry proportions."
+            ancestry_message = f"Could not solve for parameters fixed by ancestry proportions. Final error: {round(error,3)}. This can happen when no sex bias parameter allows for the observed ancestry proportions."
             self.logger.info(ancestry_message)
             if show_ancestry_warning:
                 print("At the end of the current optimization step: " + ancestry_message)

--- a/tracts/driver.py
+++ b/tracts/driver.py
@@ -501,18 +501,6 @@ def run_model_multi_init(model_func: Callable, bound_func: Callable, population:
     if len(start_params_list) == 0:
         raise ValueError("start_params_list cannot be empty. Provide at least one starting-parameter set.")
 
-    if print_subtitle:
-        subtitle_message = _get_optimization_subtitle(
-            parameter_handler=parameter_handler,
-            two_steps_optimization=two_steps_optimization,
-            autosomes_in_step_2=autosomes_in_step_2,
-            steps=steps,
-        )
-
-        for l in ["-" * len(subtitle_message), subtitle_message, "-" * len(subtitle_message)]:
-            print(l)
-            logger.info(l)
-
     if print_start_params_table:
         _print_run_intro(
             parameter_handler=parameter_handler,

--- a/tracts/driver.py
+++ b/tracts/driver.py
@@ -8,9 +8,10 @@ from tracts.core import optimize_cob_sex_biased_single_step, optimize_cob_sex_bi
 from tracts.util import time_to_physical_function, rate_to_physical_function, sex_bias_to_physical_function, time_to_optimizer_function, rate_to_optimizer_function, sex_bias_to_optimizer_function
 from tracts.demography.parameter import ParamType
 from tracts.demography.base_parametrized_demography import FixedParametersHandler
-from tracts.driver_utils import locate_file_path, load_driver_file, load_population, load_model_from_driver, get_time_scaled_model_func, get_time_scaled_model_bounds, parse_start_params, output_simulation_data_sex_biased
+from tracts.driver_utils import locate_file_path, load_driver_file, load_population, load_model_from_driver, get_time_scaled_model_func, get_time_scaled_model_bounds, parse_start_params, collapse_identical_start_params, output_simulation_data_sex_biased, _summarize_step_results, _normalize_multi_init_result, _print_run_intro, _get_optimization_subtitle
 from tracts.logs import setup_logger, set_log_file, close_log_file
 logger = logging.getLogger(__name__)
+
 
 def run_tracts(driver_filename: str, script_dir: str):
     """
@@ -68,7 +69,6 @@ def run_tracts(driver_filename: str, script_dir: str):
         # ------ Print initial information -------
         print('------------------------------------------------------------------------------------------------\n')
         print('Running tracts 2.0 with driver file:', driver_filename,'\n')
-        print('Reading data, demographic model and driver specifications...\n')
         print('------------------------------------------------------------------------------------------------\n')   
         for message in (output_message, logger_message, tracts_below_cm_message):
             print(message)
@@ -120,12 +120,12 @@ def run_tracts(driver_filename: str, script_dir: str):
         for label in data_labels:
             if label not in ancestor_labels and label not in pop.unknown_labels:
                 raise ValueError(f"Population label '{label}' found in data but not in model or labels to be smoothed over. data labels: {data_labels}, model labels: {ancestor_labels}, " \
-                "unknown labels: {pop.unknown_labels}")
+                f"unknown labels: {pop.unknown_labels}")
 
         # ------ Calculate ancestry proportions and set up fixed parameters if specified in the driver -------
         ancestry_proportions = pop.calculate_ancestry_proportions(ancestor_labels)
         
-        print("Ancestries:", [ancestry for ancestry in ancestor_labels] )
+        print(f"Ancestries: {', '.join(ancestor_labels)}")
         print("Data autosome proportions:", ancestry_proportions )
         if len(allosome_labels)>=1:
             allosome_proportions = pop.calculate_allosome_proportions(population_labels=ancestor_labels,
@@ -147,7 +147,20 @@ def run_tracts(driver_filename: str, script_dir: str):
                                             proportions= {model.parametrized_populations[0]:ancestry_proportions}) # Here, the option params_to_fix_by_value can be added in future development
         else: # No parameters to fix 
             model.set_up_fixed_parameters([],{})
-        print("Model parameters :",[param_name for param_name in model.model_base_params.keys()]) # Print model parameters
+        print(f"Model parameters: {', '.join(model.model_base_params.keys())}") # Print model parameters
+        if len(driver_spec.fix_parameters_from_ancestry_proportions) > 0:
+            fixed_params = ", ".join(driver_spec.fix_parameters_from_ancestry_proportions)
+            print(f"The following parameters have been fixed from ancestry proportions: {fixed_params}")
+
+        if ad_model_allosomes is not None:
+            admixture_model_message = (
+                f"Admixture is modelled with the {ad_model_autosomes} model for autosomes "
+                f"and with the {ad_model_allosomes} model for allosomes."
+            )
+        else:
+            admixture_model_message = f"Admixture is modelled with the {ad_model_autosomes} model for autosomes."
+        print(admixture_model_message)
+        logger.info(admixture_model_message)
 
         # ------ Optimizer setup -------
         func = get_time_scaled_model_func(model) # Time parameters need to be rescaled for some optimizers, so we create a wrapper function that applies the necessary rescaling before passing parameters to the model.
@@ -163,69 +176,71 @@ def run_tracts(driver_filename: str, script_dir: str):
         model.parameter_handler.to_physical_params_functions = to_physical_params_functions
         model.parameter_handler.to_optimizer_params_functions = to_optimizer_params_functions
 
+        model_param_names = list(model.model_base_params.keys())
+        sex_bias_param_names = [
+            name for name, info in model.model_base_params.items()
+            if info.type == ParamType.SEX_BIAS
+        ]
+        non_sex_bias_param_names = [
+            name for name in model_param_names
+            if name not in sex_bias_param_names
+        ]
+
         # Show time-admissibility warnings only during optimization and final reporting.
         model.parameter_handler.enable_time_param_logging = False
-        
+
         # ------ Compute starting parameters in physical units ------
-        physical_start_params = parse_start_params(start_param_bounds=driver_spec.start_params,
-                                                repetitions=driver_spec.repetitions, 
-                                                seed=driver_spec.seed, 
-                                                model=model)
+        if driver_spec.two_steps_optimization:
+            physical_start_params = parse_start_params(
+                start_param_bounds=driver_spec.start_params,
+                repetitions=driver_spec.repetitions,
+                seed=driver_spec.seed,
+                model=model,
+                sample_param_names=set(non_sex_bias_param_names),
+                fixed_param_values={name: 0.0 for name in sex_bias_param_names},
+            )
+            physical_start_params = collapse_identical_start_params(physical_start_params, "step 1")
+        else:
+            physical_start_params = parse_start_params(
+                start_param_bounds=driver_spec.start_params,
+                repetitions=driver_spec.repetitions,
+                seed=driver_spec.seed,
+                model=model,
+            )
+        
         # ------ Convert starting parameters to optimizer units ------
         optimizer_start_params = [model.parameter_handler.convert_to_optimizer_params(params) for params in physical_start_params]   
 
         # ------ Message about starting parameters setup ------ 
         if len(physical_start_params) > 1: # Multiple runs with different starting parameters
-            mult_params_message = "Multiple starting parameters were generated. These will be converted to optimizer units and used for multiple optimization runs."
+            mult_params_message = "Multiple starting parameters will be generated and used for multiple optimization runs."
             logger.info(mult_params_message)
-            print("\n"+mult_params_message+"\n")
+            print(mult_params_message+"\n")
 
         else: # Single run with one set of starting parameters
             single_params_message = "A single set of starting parameters was generated. It will be converted to optimizer units and used for optimization."
             logger.info(single_params_message)
-            print("\n"+single_params_message+"\n")
+            print(single_params_message+"\n")
 
         # ------ Print starting parameters in physical units ------
         n_start_params = len(physical_start_params[0]) if len(physical_start_params) > 0 else 0
-        model_param_names = list(model.model_base_params.keys())
         assert len(model_param_names) == n_start_params
         start_param_names = model_param_names
 
-        param_col_widths = [max(len(name), 12) for name in start_param_names]
-        header = f"{'Run':>3} | " + " | ".join(
-            f"{name:>{w}}" for name, w in zip(start_param_names, param_col_widths)
-        )
-        line = "-" * len(header)
-
-        for l in (header, line):
-            print(l)
-            logger.info(l)
-        
-        # ------ Check that starting parameters are correctly converted to optimizer units and within bounds ------
-        for i, (phys, opt) in enumerate(zip(physical_start_params, optimizer_start_params)):
-            assert np.isclose(phys, model.parameter_handler.convert_to_physical_params(opt)).all()
-            if bound(opt)<0:
-                print("Warning, starting parameters are out of bounds.")
-            values_str = " | ".join(
-                f"{x:>{w}.4g}" for x, w in zip(phys, param_col_widths)
-            )
-            start_param_message = f"{1+i:>3} | {values_str}"
-            print(start_param_message)
-            logger.info(start_param_message)
-        print(line)
+        if driver_spec.two_steps_optimization:
+            step_1_start_params_title = "Starting parameters for step 1 optimization"
+        else:
+            step_1_start_params_title = "Starting parameters for single-step optimization"
         
         # ------ Get starting ancestry proportions for the starting parameters ------ 
-        # Check that the starting parameters produce reasonable ancestry proportions before optimization.
-        # Only logged for now.
+        # Check that the starting parameters produce reasonable ancestry proportions before optimization. Only logged for now.
         first_props = model.proportions_from_matrices(func(optimizer_start_params[0]))
         tract_types = list(first_props.keys())
         start_ancestry_props_message = "Starting ancestry proportions for the starting parameters"
         header = f"{'Run':>3} | " + " | ".join(f"{k:<35}" for k in tract_types)
         line = "-" * len(header)
-        #print("\n" + start_ancestry_props_message)
         logger.info(start_ancestry_props_message)
         for l in (line, header, line):
-            #print(l)
             logger.info(l)
 
         for i, opt in enumerate(optimizer_start_params):
@@ -247,52 +262,147 @@ def run_tracts(driver_filename: str, script_dir: str):
         model.parameter_handler.enable_time_param_logging = True
 
         # ------ Run the model with (multiple) starting parameters ------
-        params_found, likelihoods = run_model_multi_init(model_func=func,
-                                                        bound_func=bound,
-                                                        population=pop, 
-                                                        start_params_list=optimizer_start_params,
-                                                        population_dict=model.population_indices.items(),
-                                                        parameter_handler=model.parameter_handler,
-                                                        max_iter=driver_spec.maximum_iterations,
-                                                        exclude_tracts_below_cM=driver_spec.exclude_tracts_below_cm,
-                                                        ad_model_autosomes = ad_model_autosomes, 
-                                                        ad_model_allosomes=ad_model_allosomes,
-                                                        npts=driver_spec.npts, 
-                                                        verbose_log=driver_spec.verbose_log,
-                                                        verbose_screen=driver_spec.verbose_screen, 
-                                                        two_steps_optimization=driver_spec.two_steps_optimization)
 
-        # ------ Process and print results ------
-        formatted_likelihoods = [float(x) for x in likelihoods] # One likelihood per optimization run. If multiple runs were done, these will be printed in a table with the corresponding parameters. The best likelihood and parameters across runs will be selected as the final result.
-        physical_found_params = [model.parameter_handler.convert_to_physical_params(f_param, report_non_admissible=True) for f_param in params_found] # One set of parameters per optimization run, converted to physical units. If multiple runs were done, these will be printed in a table with the corresponding likelihoods. 
+        if driver_spec.two_steps_optimization is False: # Single-step optimization using optimize_cob_sex_biased_single_step
+
+            _print_run_intro(model.parameter_handler, model, optimizer_start_params, bound, step_1_start_params_title, False, True)
+
+            params_found, likelihoods, _full_likelihoods = _normalize_multi_init_result(run_model_multi_init(model_func=func,
+                                                            bound_func=bound,
+                                                            population=pop, 
+                                                            start_params_list=optimizer_start_params,
+                                                            population_dict=model.population_indices.items(),
+                                                            parameter_handler=model.parameter_handler,
+                                                            max_iter=driver_spec.maximum_iterations,
+                                                            exclude_tracts_below_cM=driver_spec.exclude_tracts_below_cm,
+                                                            ad_model_autosomes = ad_model_autosomes, 
+                                                            ad_model_allosomes=ad_model_allosomes,
+                                                            npts=driver_spec.npts, 
+                                                            verbose_log=driver_spec.verbose_log,
+                                                            verbose_screen=driver_spec.verbose_screen, 
+                                                            two_steps_optimization=False,
+                                                            start_params_title=step_1_start_params_title,
+                                                            print_start_params_table=False,
+                                                            print_subtitle=False))
+
+            optimal_params, optimal_likelihood = _summarize_step_results(params_found=params_found,
+                                                                        likelihoods=likelihoods,
+                                                                        parameter_handler=model.parameter_handler,
+                                                                        param_names=start_param_names)
         
-        if len(formatted_likelihoods) > 1: # Print optimal parameters and likelihoods for multiple runs with different starting parameters.
+        else: # Performs two-steps optimization with multiple starting parameters            
 
-            results_message = "\nResults from multiple optimization runs with different starting parameters:"
-            found_param_names = start_param_names
-            found_param_col_widths = [max(len(name), 12) for name in found_param_names]
-            header = f"{'Run':>3} | {'LogLik':>12} | " + " | ".join(
-                f"{name:>{w}}" for name, w in zip(found_param_names, found_param_col_widths)
-            )
-            line = "-" * len(header)
-            for l in (results_message, line, header, line):
-                print(l)
-                logger.info(l)  
+            # ------ Step 1: optimize non-sex-bias parameters on autosomal data ------
+
+            _print_run_intro(model.parameter_handler, model, optimizer_start_params, bound, step_1_start_params_title, True, driver_spec.use_autosomes_for_sex_bias, [1])
+
+            params_found_step_1, likelihoods_step_1, _full_likelihoods_step_1 = _normalize_multi_init_result(run_model_multi_init(model_func=func,
+                                                            bound_func=bound,
+                                                            population=pop, 
+                                                            start_params_list=optimizer_start_params,
+                                                            population_dict=model.population_indices.items(),
+                                                            parameter_handler=model.parameter_handler,
+                                                            max_iter=driver_spec.maximum_iterations,
+                                                            exclude_tracts_below_cM=driver_spec.exclude_tracts_below_cm,
+                                                            ad_model_autosomes = ad_model_autosomes, 
+                                                            ad_model_allosomes=ad_model_allosomes,
+                                                            npts=driver_spec.npts, 
+                                                            verbose_log=driver_spec.verbose_log,
+                                                            verbose_screen=driver_spec.verbose_screen, 
+                                                            two_steps_optimization=True,
+                                                            autosomes_in_step_2=driver_spec.use_autosomes_for_sex_bias, # This parameter is ignored in step 1
+                                                            steps=[1],
+                                                            start_params_title=step_1_start_params_title,
+                                                            print_start_params_table=False,
+                                                            print_subtitle=False))
             
-            for i, (params, ll) in enumerate(zip(physical_found_params, formatted_likelihoods)):
-                params_str = " | ".join(
-                    f"{p:>{w}.4g}" for p, w in zip(params, found_param_col_widths)
+            #  Process and print results
+            optimal_params_step_1, _optimal_likelihood_step_1 = _summarize_step_results(params_found=params_found_step_1,
+                                                                        likelihoods=likelihoods_step_1,
+                                                                        parameter_handler=model.parameter_handler,
+                                                                        param_names=start_param_names,
+                                                                        step_label="Step 1")
+
+            if ad_model_allosomes is None:
+                logger.info("No allosomal data provided. Skipping Step 2 and using Step 1 results.")
+                optimal_params, optimal_likelihood = optimal_params_step_1, _optimal_likelihood_step_1
+            else:
+                end_step_1_message = "Selecting best parameters from step 1 and proceeding to step 2 optimization.\n"
+                print(end_step_1_message)
+                logger.info(end_step_1_message)
+
+                # ------ Step 2: optimize sex-bias parameters on (autosomal and) allosomal data ------
+
+                # Draw fresh sex-bias starts for step 2, while keeping the best step 1 non-sex-bias values fixed.
+                step_2_fixed_param_values = {
+                    name: float(value)
+                    for name, value in zip(model_param_names, optimal_params_step_1)
+                    if name not in sex_bias_param_names
+                }
+                step_2_physical_start_params = parse_start_params(
+                    start_param_bounds=driver_spec.start_params,
+                    repetitions=driver_spec.repetitions,
+                    seed=driver_spec.seed,
+                    model=model,
+                    sample_param_names=set(sex_bias_param_names),
+                    fixed_param_values=step_2_fixed_param_values,
                 )
-                param_line = f"{1+i:>3} | {float(ll):>12.6g} | {params_str}"
-                print(param_line)
-                logger.info(param_line)
-            print(line)
-        
-        # Choose optimal run across multiple runs with different starting parameters, if applicable. This will be the run with the highest likelihood (lowest negative log-likelihood).
-        optimal_params, optimal_likelihood = max(zip(physical_found_params, formatted_likelihoods), key=lambda x: x[1])
-        
+                step_2_physical_start_params = collapse_identical_start_params(step_2_physical_start_params, "step 2")
+                step_2_start_params = [
+                    model.parameter_handler.convert_to_optimizer_params(params)
+                    for params in step_2_physical_start_params
+                ]
+
+                step_2_start_params_title = (
+                    "Starting parameters for step 2 optimization "
+                    "(non-sex-bias parameters are fixed to the best step 1 estimates)."
+                )
+                
+                _print_run_intro(model.parameter_handler, model, step_2_start_params, bound, step_2_start_params_title, True, driver_spec.use_autosomes_for_sex_bias, [2])
+
+                params_found_step_2, likelihoods_step_2, full_likelihoods_step_2 = _normalize_multi_init_result(run_model_multi_init(model_func=func,
+                                                                            bound_func=bound,
+                                                                            population=pop, 
+                                                                            start_params_list=step_2_start_params,
+                                                                            population_dict=model.population_indices.items(),
+                                                                            parameter_handler=model.parameter_handler,
+                                                                            max_iter=driver_spec.maximum_iterations,
+                                                                            exclude_tracts_below_cM=driver_spec.exclude_tracts_below_cm,
+                                                                            ad_model_autosomes = ad_model_autosomes, 
+                                                                            ad_model_allosomes=ad_model_allosomes,
+                                                                            npts=driver_spec.npts, 
+                                                                            verbose_log=driver_spec.verbose_log,
+                                                                            verbose_screen=driver_spec.verbose_screen, 
+                                                                            two_steps_optimization=True,
+                                                                            autosomes_in_step_2=driver_spec.use_autosomes_for_sex_bias,
+                                                                            steps=[2],
+                                                                            start_params_title=step_2_start_params_title,
+                                                                            print_start_params_table=False,
+                                                                            print_subtitle=False))
+                
+                #  Process and print results
+                optimal_params, optimal_likelihood = _summarize_step_results(params_found=params_found_step_2,
+                                                                            likelihoods=likelihoods_step_2,
+                                                                            parameter_handler=model.parameter_handler,
+                                                                            param_names=start_param_names,
+                                                                            step_label="Step 2")
+
+                end_step_2_message = "Selecting best parameters from step 2."
+                print(end_step_2_message)
+                logger.info(end_step_2_message)
+
+                if not driver_spec.use_autosomes_for_sex_bias:
+                    best_run_index = int(np.argmax([float(x) for x in likelihoods_step_2]))
+                    full_data_likelihood = full_likelihoods_step_2[best_run_index]
+                    if full_data_likelihood is not None:
+                        optimal_likelihood = float(full_data_likelihood)
+                        full_lik_message = "Step 2 used allosomal data only. Final likelihood is evaluated on autosomal + allosomal data at the selected optimal parameters."
+                        print(full_lik_message)
+                        logger.info(full_lik_message)
+
         # Print final optimal parameters and likelihood.
-        final_message = "Final parameters and corresponding likelihood:"
+        final_data = "autosomal + allosomal" if ad_model_allosomes is not None else "autosomal"
+        final_message = f"Final parameters and corresponding likelihood computed on {final_data} data:"
         param_names = list(model.model_base_params.keys())
         param_col_widths = [max(len(name), 12) for name in param_names]
         header = f"{'LogLik':>12} | " + " | ".join(
@@ -331,77 +441,127 @@ def run_model_multi_init(model_func: Callable, bound_func: Callable, population:
                         start_params_list: list[np.ndarray], population_dict : dict, parameter_handler: FixedParametersHandler, 
                         max_iter: int=None, exclude_tracts_below_cM: int = 0, ad_model_autosomes = 'DC', 
                         ad_model_allosomes = 'DC', npts: int = 50, verbose_log: int = 0, verbose_screen:int = 0, 
-                        two_steps_optimization: bool = True) -> tuple[list[np.ndarray], list[float]]:
+                        two_steps_optimization: bool = True, autosomes_in_step_2: bool = True,
+                        steps: list[int | str] | None = None, start_params_title: str | None = None,
+                        print_start_params_table: bool = True,
+                        print_subtitle: bool = True) -> tuple[list[np.ndarray], list[float], list[float | None]]:
     """
     Runs the model multiple times with different initial parameters.
 
     Parameters
     ----------
-    
-        model_func: Callable
-    	    A function that takes parameters and returns migration matrices.
-        bound_func: Callable
-    	    A function that calculates the violation score for the parameters. 	
-        population: :class:`tracts.population.Population`
-    	    The population object containing individual data.
-        start_params_list: list[np.ndarray]
-    	    A list of initial parameter arrays to start the optimization.
-        population_dict: dict
-            A dictionary mapping population labels to their corresponding indices in the model.
-        parameter_handler: FixedParametersHandler
-            An object that handles parameter transformations and fixed parameters.
-        max_iter: int, optional
-            Maximum number of iterations for the optimization algorithm. Default is None, which means no limit.
-        exclude_tracts_below_cM: int, optional
-    	    Minimum tract length in centimorgans to exclude from analysis. Default is 0.
-        ad_model_autosomes: str, optional
-            The model to use for autosomal admixture. Must be one of 'DC', 'DF', 'M', 'H-DC' or 'H-DF'. Default is 'DC'.
-        ad_model_allosomes: str or None, optional
-            The model to use for allosomal admixture. Must be one of 'DC', 'DF', 'H-DC' or 'H-DF', or None if allosomal admixture is not to be modeled. Default is 'DC'.
-        npts: int, optional
-            Number of bins for the tract length histogram. Default is 50.
-        verbose_log: int, optional
-            Verbosity level for logging. Default is 0 (no verbose output). If greater than 0, iterations are logged every ``verbose_log`` steps.
-        verbose_screen: int, optional
-            Verbosity level for screen prints. Default is 0 (no verbose output). If greater than 0, iterations are printed every ``verbose_screen`` steps.
-        two_steps_optimization: bool, optional
-            Whether to use a two-step optimization procedure for sex-biased models. Default is True.
-
+    model_func: Callable
+        A function that takes parameters and returns migration matrices.
+    bound_func: Callable
+    	A function that calculates the violation score for the parameters. 	
+    population: :class:`tracts.population.Population`
+        The population object containing individual data.
+    start_params_list: list[np.ndarray]
+    	A list of initial parameter arrays to start the optimization.
+    population_dict: dict
+        A dictionary mapping population labels to their corresponding indices in the model.
+    parameter_handler: FixedParametersHandler
+        An object that handles parameter transformations and fixed parameters.
+    max_iter: int, optional
+        Maximum number of iterations for the optimization algorithm. Default is None, which means no limit.
+    exclude_tracts_below_cM: int, optional
+    	Minimum tract length in centimorgans to exclude from analysis. Default is 0.
+    ad_model_autosomes: str, optional
+        The model to use for autosomal admixture. Must be one of 'DC', 'DF', 'M', 'H-DC' or 'H-DF'. Default is 'DC'.
+    ad_model_allosomes: str or None, optional
+        The model to use for allosomal admixture. Must be one of 'DC', 'DF', 'H-DC' or 'H-DF', or None if allosomal admixture is not to be modeled. Default is 'DC'.
+    npts: int, optional
+        Number of bins for the tract length histogram. Default is 50.
+    verbose_log: int, optional
+        Verbosity level for logging. Default is 0 (no verbose output). If greater than 0, iterations are logged every ``verbose_log`` steps.
+    verbose_screen: int, optional
+        Verbosity level for screen prints. Default is 0 (no verbose output). If greater than 0, iterations are printed every ``verbose_screen`` steps.
+    two_steps_optimization: bool, optional
+        Whether to use a two-step optimization procedure for sex-biased models. Default is True.
+    autosomes_in_step_2: bool, optional
+        If two_steps_optimization is True, whether both autosomal and allosomal data will be used in the second optimization step. If True, both types of data will be used. If False, only allosomal data will be used in the second step. Default is True.
+    steps: list[int | str] | None, optional
+        If two_steps_optimization is True, a list specifying which steps to run. Step 1 (non-sex-bias parameter optimization) can be denoted as 1 or 'step1', and step 2 (sex-bias parameter optimization)
+        can be denoted as 2 or 'step2'. The only allowed combinations are step 1 only, step 2 only, or both steps.
+        Examples of valid values are [1], ['step1'], [2], ['step2'], [1, 2], or ['step1', 'step2'].
+        Mixed types are allowed, but duplicate references to the same step such as [1, 'step1'] are not. Default is None (both steps will be run).
+    start_params_title: str or None, optional
+        For internal use only. An optional title to display above the starting parameters table. If None, a default title will be generated based on the steps being run. Default is None.     
+    print_start_params_table: bool, optional
+        For internal use only. Whether to print the starting parameters table. Default is True.
+    print_subtitle: bool, optional
+        For internal use only. Whether to print a subtitle message describing the optimization run. Default is True.
+        
     Returns
     ----------
-    tuple[list[np.ndarray], list[float]]
-    	A tuple containing two lists: (i) a list of optimal parameters found for each set of starting parameters and (ii) a list of likelihoods corresponding to the optimal parameters.
+    tuple[list[np.ndarray], list[float], list[float | None]]
+        A tuple containing three lists: (i) optimal parameters for each run, (ii) optimization likelihoods for each run, and (iii) optional
+        full-data likelihoods (only populated when step 2 is run with allosomal data only).
     """
-    
+    if len(start_params_list) == 0:
+        raise ValueError("start_params_list cannot be empty. Provide at least one starting-parameter set.")
+
+    if print_subtitle:
+        subtitle_message = _get_optimization_subtitle(
+            parameter_handler=parameter_handler,
+            two_steps_optimization=two_steps_optimization,
+            autosomes_in_step_2=autosomes_in_step_2,
+            steps=steps,
+        )
+
+        for l in ["-" * len(subtitle_message), subtitle_message, "-" * len(subtitle_message)]:
+            print(l)
+            logger.info(l)
+
+    if print_start_params_table:
+        _print_run_intro(
+            parameter_handler=parameter_handler,
+            model=parameter_handler.demography if hasattr(parameter_handler, "demography") else None,
+            start_params_list=start_params_list,
+            bound_func=bound_func,
+            title_message=start_params_title,
+            two_steps_optimization=two_steps_optimization,
+            autosomes_in_step_2=autosomes_in_step_2,
+            steps=steps,
+        )
+
     optimal_params = []
     likelihoods = []
+    full_likelihoods = []
+    
     for start_params in start_params_list:
         opt_run_message = f"Optimization run #{len(optimal_params)+1}"
         print("\n" + opt_run_message + "\n")
         logger.info(opt_run_message)
+        
         logger.debug(f'Starting parameters in optimizer units: {start_params}')
-        params_found, likelihood_found = run_model(model_func=model_func,
-                                                   bound_func=bound_func, 
-                                                   population=population, 
-                                                   startparams=start_params,
-                                                   population_dict=population_dict,
-                                                   parameter_handler=parameter_handler,
-                                                   max_iter=max_iter,
-                                                   exclude_tracts_below_cM=exclude_tracts_below_cM,
-                                                   ad_model_autosomes=ad_model_autosomes,
-                                                   ad_model_allosomes=ad_model_allosomes,
-                                                   npts=npts,
-                                                   verbose_log=verbose_log,
-                                                   verbose_screen=verbose_screen,
-                                                   two_steps_optimization=two_steps_optimization)
+        params_found, likelihood_found, full_likelihood_found = run_model(model_func=model_func,
+                                                                        bound_func=bound_func, 
+                                                                        population=population, 
+                                                                        startparams=start_params,
+                                                                        population_dict=population_dict,
+                                                                        parameter_handler=parameter_handler,
+                                                                        max_iter=max_iter,
+                                                                        exclude_tracts_below_cM=exclude_tracts_below_cM,
+                                                                        ad_model_autosomes=ad_model_autosomes,
+                                                                        ad_model_allosomes=ad_model_allosomes,
+                                                                        npts=npts,
+                                                                        verbose_log=verbose_log,
+                                                                        verbose_screen=verbose_screen,
+                                                                        two_steps_optimization=two_steps_optimization,
+                                                                        autosomes_in_step_2=autosomes_in_step_2,
+                                                                        steps=steps,
+                                                                        print_step_header=False)
         optimal_params.append(params_found)
         likelihoods.append(likelihood_found)
-    return optimal_params, likelihoods
+        full_likelihoods.append(full_likelihood_found)
+    return optimal_params, likelihoods, full_likelihoods
 
 def run_model(model_func: callable, bound_func: callable, population: Population, 
                         startparams: list, population_dict: dict, parameter_handler: FixedParametersHandler, max_iter: int | None = None, 
                         exclude_tracts_below_cM: float = 0, ad_model_autosomes: str = 'DC', ad_model_allosomes: str = 'DC',
-                        npts: int = 0, verbose_log: int = 0, verbose_screen: int = 0, two_steps_optimization: bool = True):
+                        npts: int = 0, verbose_log: int = 0, verbose_screen: int = 0, two_steps_optimization: bool = True,
+                        autosomes_in_step_2: bool = True, steps: list[int | str] | None = None, print_step_header: bool = True) -> tuple[np.ndarray, float, float | None]:
     
     """
     Runs the optimization for any demographic model, including sex-biased models. Works with only autosomal admixture or with both autosomal and allosomal admixture.
@@ -436,11 +596,24 @@ def run_model(model_func: callable, bound_func: callable, population: Population
         Verbosity level for screen prints. Default is 0. If greater than 0, iterations are printed every ``verbose_screen`` steps.
     two_steps_optimization: bool, optional
         Whether to use a two-step optimization procedure for sex-biased models. If True, the optimization will first be run on non-sex bias parameters using only autosomal data. Then, a second optimization will be run with sex-bias parameters using both autosomal and allosomal data, starting from the results of the first optimization. Default is True.  
-    
+    autosomes_in_step_2: bool, optional
+        If two_steps_optimization is True, whether both autosomal and allosomal data will be used in the second optimization step. If True, both types of data will be used. If False, only allosomal data will be used in the second step. Default is True.
+    steps: list[int | str] | None, optional
+        If two_steps_optimization is True, a list specifying which steps to run. Step 1 (non-sex-bias parameter optimization) can be denoted as 1 or 'step1', and step 2 (sex-bias parameter optimization)
+        can be denoted as 2 or 'step2'. The only allowed combinations are step 1 only, step 2 only, or both steps.
+        Examples of valid values are [1], ['step1'], [2], ['step2'], [1, 2], or ['step1', 'step2'].
+        Mixed types are allowed, but duplicate references to the same step such as [1, 'step1'] are not. Default is None (both steps will be run).
+    print_step_header: bool, optional
+        If True, print the admixture-model title and step subtitle at the start of the optimization.
+        If False, only the iteration table header is printed. For internal use only; set
+        automatically by :func:`~tracts.driver.run_model_multi_init` to suppress repeated headers
+        across multiple runs within the same step. Default is True.
+        
     Returns
     ----------
-    tuple [np.ndarray, float]
-        A tuple containing the optimal parameters found and the corresponding likelihood.
+    tuple [np.ndarray, float, float | None]
+        A tuple containing the optimal parameters found, the corresponding
+        optimization likelihood, and an optional full-data likelihood.
     """
     if not two_steps_optimization:
         optimal_params, optimal_likelihood = optimize_cob_sex_biased_single_step(p0=startparams, 
@@ -455,21 +628,27 @@ def run_model(model_func: callable, bound_func: callable, population: Population
                                                                     verbose_screen=verbose_screen,
                                                                     ad_model_autosomes=ad_model_autosomes, 
                                                                     ad_model_allosomes=ad_model_allosomes,
-                                                                    npts=npts)
+                                                                    npts=npts,
+                                                                    print_step_header=print_step_header)
+        full_data_likelihood = None
     else:
-        optimal_params, optimal_likelihood = optimize_cob_sex_biased_two_steps(p0=startparams, 
-                                                                                population=population, 
-                                                                                model_func=model_func, 
-                                                                                parameter_handler= parameter_handler, 
-                                                                                outofbounds_fun = bound_func, 
-                                                                                p_dict = population_dict, 
-                                                                                exclude_tracts_below_cM=exclude_tracts_below_cM, 
-                                                                                maxiter=max_iter,
-                                                                                verbose_log=verbose_log,
-                                                                                verbose_screen=verbose_screen,
-                                                                                ad_model_autosomes=ad_model_autosomes, 
-                                                                                ad_model_allosomes=ad_model_allosomes,
-                                                                                npts=npts)    
+        optimal_params, optimal_likelihood, full_data_likelihood = optimize_cob_sex_biased_two_steps(p0=startparams, 
+                                                                                                       population=population, 
+                                                                                                       model_func=model_func, 
+                                                                                                       parameter_handler= parameter_handler, 
+                                                                                                       outofbounds_fun = bound_func, 
+                                                                                                       p_dict = population_dict, 
+                                                                                                       exclude_tracts_below_cM=exclude_tracts_below_cM, 
+                                                                                                       maxiter=max_iter,
+                                                                                                       verbose_log=verbose_log,
+                                                                                                       verbose_screen=verbose_screen,
+                                                                                                       ad_model_autosomes=ad_model_autosomes, 
+                                                                                                       ad_model_allosomes=ad_model_allosomes,
+                                                                                                       autosomes_in_step_2=autosomes_in_step_2,
+                                                                                                       steps=steps,
+                                                                                                       npts=npts,
+                                                                                                       print_step_header=print_step_header,
+                                                                                                       return_full_likelihood=True)
     
-    return optimal_params, optimal_likelihood
+    return optimal_params, optimal_likelihood, full_data_likelihood
        

--- a/tracts/driver_utils.py
+++ b/tracts/driver_utils.py
@@ -15,6 +15,8 @@ from tracts.phase_type import PhTMonoecious, PhTDioecious
 from tracts.demography.parametrized_demography import ParametrizedDemography
 from tracts.demography.parametrized_demography_sex_biased import ParametrizedDemographySexBiased
 from tracts.demography.parametrized_demography_sex_biased import SexType
+from tracts.demography.base_parametrized_demography import FixedParametersHandler
+from tracts.demography.parameter import ParamType
 import ruamel.yaml as yaml
 from pydantic import BaseModel, ConfigDict, Field
 from typing import List
@@ -22,7 +24,9 @@ from pydantic_core import PydanticUndefined
 import logging
 logger = logging.getLogger(__name__)
 
-# ---------- Driver file setup ----------
+
+# --------------- Locate driver file ---------------
+
 
 def locate_file_path(filename: str, 
                     script_dir: str | Path | None,
@@ -82,7 +86,7 @@ def locate_file_path(filename: str,
 
     return None
 
-# ---------- Models ----------
+# --------------- Models ---------------
 
 class SamplesConfig(BaseModel):
     """
@@ -174,6 +178,8 @@ class InferenceConfig(BaseModel):
         Whether to use log scale to plot the tract length distribution. Defaults to True.
     two_steps_optimization: bool
         Whether to perform a two-step optimization process, where the first step optimizes only the non-sex-bias parameters on autosomal data and the second step optimizes sex-bias parameters using both autosomal and allosomal data. Defaults to True.
+    use_autosomes_for_sex_bias: bool
+        Whether step 2 should include autosomal data in addition to allosomal data. Defaults to False.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -196,8 +202,11 @@ class InferenceConfig(BaseModel):
     verbose_screen: int = 30
     log_scale: bool = True
     two_steps_optimization: bool = True
+    use_autosomes_for_sex_bias: bool = False
 
-# ---------- Driver file setup ----------
+
+# --------------- Driver file setup ---------------
+
 
 filepath_error_additional_message = (
     '\nPlease ensure that the file path is either absolute,'
@@ -241,7 +250,9 @@ def load_driver_file(driver_path: str) -> InferenceConfig:
 
     return InferenceConfig.model_validate(driver_spec)
 
-# ---------- Loader ----------
+
+# --------------- Loader ---------------
+
 
 def parse_individual_filenames(
     individual_names: List[str],
@@ -425,7 +436,8 @@ def load_model_from_driver(driver_spec: InferenceConfig, script_dir: str | Path 
         model = ParametrizedDemography.load_from_YAML(str(model_path.resolve()))
     return model
 
-def parse_start_params(start_param_bounds, repetitions: int=1, seed: float=None, model: ParametrizedDemography = None):
+def parse_start_params(start_param_bounds, model: ParametrizedDemography, repetitions: int=1, seed: float | None = None,
+                       sample_param_names: set[str] | None = None, fixed_param_values: dict[str, float] | None = None):
     """
     Produces starting parameters for optimization in physical units. Only produces starting parameters that are compatible with well-defined migration matrices.
     
@@ -433,13 +445,20 @@ def parse_start_params(start_param_bounds, repetitions: int=1, seed: float=None,
     ----------
     start_param_bounds
         An object containing attributes corresponding to each parameter in model.model_base_parameters, where the value of each attribute is either a single number (if the starting value for that parameter should be fixed) or a string of the form "min:max" specifying the range from which to sample starting values for that parameter. The parameters specified in start_param_bounds must match those in model.model_base_parameters, and an error will be raised if any parameters are missing or if any extra parameters are included.
-    repetitions: int
-        The number of sets of starting parameters to produce. Defaults to 1.
-    seed: float
-        The random seed to use for sampling starting parameters. Defaults to None.
     model: ParametrizedDemography
         The demographic model for which to produce starting parameters. 
-
+    repetitions: int
+        The number of sets of starting parameters to produce. Defaults to 1.
+    seed: float | None
+        The random seed to use for sampling starting parameters. Defaults to None.
+    sample_param_names: set[str] | None
+        Optional subset of parameter names to sample from ``start_param_bounds``.
+        If provided, all other non-ancestry-fixed parameters must be supplied in
+        ``fixed_param_values``.
+    fixed_param_values: dict[str, float] | None
+        Optional parameter values to hold fixed while sampling the remaining
+        parameters.
+    
     Returns
     -------
     list[np.ndarray]: A list of arrays of starting parameters in physical units, where each array corresponds to a set of starting parameters for one repetition of the optimization. The parameters are ordered according to their order in model.model_base_parameters.
@@ -463,6 +482,8 @@ def parse_start_params(start_param_bounds, repetitions: int=1, seed: float=None,
     
     num_params = len(model.model_base_params)
     rng = np.random.default_rng(seed=seed)
+    sampled_param_names = set(sample_param_names) if sample_param_names is not None else None
+    fixed_param_values = {} if fixed_param_values is None else dict(fixed_param_values)
 
     # ------- Support Pydantic models, plain mappings, and attribute-style config objects -------
     start_param_values = None
@@ -503,6 +524,15 @@ def parse_start_params(start_param_bounds, repetitions: int=1, seed: float=None,
 
     parsed_specs = {}
     for param_name, param_info in model.model_base_params.items():
+        if param_name in fixed_param_values:
+            parsed_specs[param_name] = ("fixed", float(fixed_param_values[param_name]))
+            continue
+
+        if sampled_param_names is not None and param_name not in sampled_param_names and param_name not in model.params_fixed_by_ancestry:
+            raise KeyError(
+                f"Parameter '{param_name}' must be provided in fixed_param_values when sampling only a subset of parameters."
+            )
+
         if param_name in model.params_fixed_by_ancestry: # Ancestry-fixed parameters do not need to be present in start_param_bounds and default to model lower bound.
             if not has_start_param(param_name):
                 parsed_specs[param_name] = ("fixed", float(param_info.bounds[0]))
@@ -587,10 +617,40 @@ def parse_start_params(start_param_bounds, repetitions: int=1, seed: float=None,
             start_params.append(candidate)
 
     if len(start_params) < repetitions:
-        raise ValueError(
-            f"Could not generate {repetitions} feasible starting parameter sets after {attempts} attempts. "
-            "Try widening valid start ranges or tightening cross-parameter constraints in the model."
-        )
+        raise ValueError(f"Could not generate {repetitions} feasible starting parameter sets after {attempts} attempts. Try widening valid start ranges.")
+        
+    return start_params
+
+
+def collapse_identical_start_params(start_params: list[np.ndarray], step_label: str) -> list[np.ndarray]:
+    """
+    Collapse repeated identical starting-parameter sets to a single repetition.
+
+    This is used when all generated starting parameters for a step are the same,
+    for example because the inputs were specified as single fixed values or
+    because ancestry-fixed parameters made every draw collapse to the same point.
+
+    Parameters
+    ----------
+    start_params: list[np.ndarray]
+        Candidate starting-parameter sets for one optimization step.
+    step_label: str
+        Human-readable label used in the warning message (for example,
+        ``"step 1"`` or ``"step 2"``).
+
+    Returns
+    -------
+    list[np.ndarray]
+        The original list if it contains zero or one entry, or a single-entry
+        list containing the unique start if every entry is identical.
+    """
+    if len(start_params) <= 1:
+        return start_params
+
+    first = np.asarray(start_params[0], dtype=float)
+    if all(np.allclose(np.asarray(candidate, dtype=float), first) for candidate in start_params[1:]):
+        logger.warning(f"All generated starting parameters for {step_label} are identical: running a single optimization instead of multiple repetitions.")
+        return [np.array(first, copy=True)]
 
     return start_params
 
@@ -643,8 +703,8 @@ def scale_select_indices(arr, indices_to_scale, scaling_factor=1):
 
 
 
+# --------------- Output production ---------------
 
-# ----- Output production -----
 
 def output_simulation_data_sex_biased(sample_population: Population,
                                     optimal_params: np.ndarray, 
@@ -1099,3 +1159,390 @@ def output_simulation_data_sex_biased(sample_population: Population,
     logger.info('Results saved to : ' + str(output_dir))
 
 
+
+# --------------- Helper function to summarize optimization results and choose best likelihood ---------------
+
+
+def _summarize_step_results(params_found: list[np.ndarray], likelihoods: list[float], parameter_handler: FixedParametersHandler,
+                            param_names: list[str], step_label: str | None = None) -> tuple[list[np.ndarray], list[float], np.ndarray, float]:
+    """
+    Print per-run optimization results and select the best run.
+
+    Parameters
+    ----------
+    params_found: list[np.ndarray]
+        A list of arrays of parameters found by the optimization runs, where each array corresponds to one run and is in optimizer parameter space.
+    likelihoods: list[float] 
+        A list of likelihoods corresponding to each set of parameters found by the optimization runs.
+    parameter_handler: FixedParametersHandler
+        The parameter handler for the model.
+    param_names: list[str]
+        A list of parameter names corresponding to the parameters in the model, used for printing results.
+    step_label: str | None
+        A label for the optimization step, used for printing results.
+
+    Returns
+    -------
+    np.ndarray
+        An array of the optimal parameters in physical parameter space, corresponding to the highest likelihood among the runs.
+    float
+        The optimal likelihood as a float.
+    """
+    formatted_likelihoods = [float(x) for x in likelihoods]
+    
+    prev_time_param_logging = parameter_handler.enable_time_param_logging # Keep time-transition warnings tied to optimization iterations, not to post-run summary conversions.
+    parameter_handler.enable_time_param_logging = False
+    try:
+        physical_found_params = [
+            parameter_handler.convert_to_physical_params(found, report_non_admissible=False)
+            for found in params_found
+        ]
+    finally:
+        parameter_handler.enable_time_param_logging = prev_time_param_logging
+
+    if len(formatted_likelihoods) > 1:
+        step_prefix = f"{step_label}: " if step_label else ""
+        results_message = f"\n{step_prefix}Results from multiple optimization runs with different starting parameters:"
+        found_param_col_widths = [max(len(name), 12) for name in param_names]
+        header = f"{'Run':>3} | {'LogLik':>12} | " + " | ".join(
+            f"{name:>{w}}" for name, w in zip(param_names, found_param_col_widths)
+        )
+        line = "-" * len(header)
+        for message_line in (results_message, line, header, line):
+            print(message_line)
+            logger.info(message_line)
+
+        for i, (params, ll) in enumerate(zip(physical_found_params, formatted_likelihoods)):
+            params_str = " | ".join(
+                f"{p:>{w}.4g}" for p, w in zip(params, found_param_col_widths)
+            )
+            param_line = f"{1+i:>3} | {float(ll):>12.6g} | {params_str}"
+            print(param_line)
+            logger.info(param_line)
+        print(line)
+
+    optimal_params, optimal_likelihood = max(
+        zip(physical_found_params, formatted_likelihoods),
+        key=lambda x: x[1],
+    )
+    return optimal_params, float(optimal_likelihood)
+
+
+def _print_step_header_block(parameter_handler: FixedParametersHandler, start_params_list: list[np.ndarray] | None = None,
+                            bound_func: Callable[[np.ndarray], float] | None = None, title_message: str | None = None, display_param_indices: list[int] | None = None) -> None:
+    """
+    Print starting-parameter information before optimization runs begin.
+
+    This helper is for internal use only. It prints a starting-parameter table that is
+    logged and shown once before optimization runs begin.
+
+    Parameters
+    ----------
+    parameter_handler: FixedParametersHandler
+        Used to derive parameter labels and convert optimizer-space values for display.
+    start_params_list: list[np.ndarray] | None
+        Starting parameters in optimizer units. If provided together with
+        ``bound_func``, a starting-parameters table is printed.
+    bound_func: Callable[[np.ndarray], float] | None
+        Function returning a violation score in optimizer space. Used to flag
+        out-of-bounds starting values when printing the table.
+    title_message: str | None
+        Optional title shown above the starting-parameters table.
+    display_param_indices: list[int] | None
+        Indices of parameters to display in the table. If None, defaults to
+        current free-parameter indices from ``parameter_handler``.
+    """
+    if start_params_list is None or bound_func is None:
+        return
+
+    if display_param_indices is None:
+        if hasattr(parameter_handler, "free_parameters_indices"):
+            display_param_indices = list(parameter_handler.free_parameters_indices)
+        else:
+            display_param_indices = list(range(len(parameter_handler.convert_to_physical_params(start_params_list[0], report_non_admissible=False))))
+
+    physical_params_list = [
+        parameter_handler.convert_to_physical_params(params, report_non_admissible=False)[display_param_indices]
+        for params in start_params_list
+    ]
+    if hasattr(parameter_handler, "indices_to_labels"):
+        param_names = list(parameter_handler.indices_to_labels(display_param_indices))
+    else:
+        param_names = [str(index) for index in display_param_indices]
+    param_col_widths = [max(len(name), 12) for name in param_names]
+
+    if title_message is None:
+        title_message = "Starting parameters"
+
+    print(title_message)
+    logger.info(title_message)
+
+    table_header = f"{'Run':>3} | " + " | ".join(
+        f"{name:>{w}}" for name, w in zip(param_names, param_col_widths)
+    )
+    table_line = "-" * len(table_header)
+
+    for l in (table_line, table_header, table_line):
+        print(l)
+        logger.info(l)
+
+    for i, (phys, opt) in enumerate(zip(physical_params_list, start_params_list)):
+        assert np.isclose(
+            phys,
+            parameter_handler.convert_to_physical_params(opt)[display_param_indices]
+        ).all()
+        if bound_func(opt) < 0:
+            warning_message = "Warning, starting parameters are out of bounds."
+            print(warning_message)
+            logger.info(warning_message)
+        values_str = " | ".join(
+            f"{x:>{w}.4g}" for x, w in zip(phys, param_col_widths)
+        )
+        start_param_message = f"{1+i:>3} | {values_str}"
+        print(start_param_message)
+        logger.info(start_param_message)
+
+    print(table_line)
+    logger.info(table_line)
+
+
+def _normalize_multi_init_result(result):
+    """
+    Normalize outputs from multi-initialization optimization runs.
+
+    This helper accepts legacy 2-item return values as well as the current
+    3-item return shape and always returns a 3-tuple:
+    ``(params_found, likelihoods, full_likelihoods)``.
+
+    Parameters
+    ----------
+    result
+        Tuple returned by ``run_model_multi_init``. Supported forms are: ``(params_found, likelihoods)`` or ``(params_found, likelihoods, full_likelihoods)``.
+
+    Returns
+    -------
+    tuple
+        A 3-item tuple ``(params_found, likelihoods, full_likelihoods)``. If ``result`` has only two items, ``full_likelihoods`` is filled with
+        ``None`` values matching the number of runs.
+
+    Raises
+    ------
+    ValueError
+        If ``result`` does not contain exactly 2 or 3 items.
+    """
+    if len(result) == 3:
+        return result
+    if len(result) == 2:
+        params_found, likelihoods = result
+        return params_found, likelihoods, [None] * len(params_found)
+    raise ValueError("run_model_multi_init must return either 2 or 3 values.")
+
+
+def _get_display_param_indices(parameter_handler: FixedParametersHandler,
+                               model,
+                               two_steps_optimization: bool,
+                               steps: list[int | str] | None = None) -> list[int]:
+    """
+    Compute which parameter columns should be shown in starting-parameter tables.
+
+    The selected indices depend on whether optimization is single-step or
+    two-step and, for two-step mode, which step is active.
+
+    Parameters
+    ----------
+    parameter_handler: FixedParametersHandler
+        Parameter handler containing free/fixed parameter metadata.
+    model
+        Demography model used as a fallback source for parameter metadata when ``parameter_handler.demography`` is unavailable.
+    two_steps_optimization: bool
+        Whether optimization runs in two-step mode.
+    steps: list[int | str] | None
+        Active step selection (e.g. ``[1]``, ``[2]``, ``[1, 2]``,
+        ``["step1"]``, ``["step2"]``).
+
+    Returns
+    -------
+    list[int]
+        Parameter indices to display in the table for the active optimization  context.
+    """
+    if not two_steps_optimization:
+        if hasattr(parameter_handler, "free_parameters_indices"):
+            return list(parameter_handler.free_parameters_indices)
+        return list(range(len(model.model_base_params)))
+
+    step_2_only = bool(steps) and all(step in (2, "step2") for step in steps)
+    model_base_params = (
+        parameter_handler.demography.model_base_params
+        if hasattr(parameter_handler, "demography")
+        else model.model_base_params
+    )
+    user_params_fixed_by_value = getattr(parameter_handler, "user_params_fixed_by_value", {})
+    params_fixed_by_ancestry = getattr(parameter_handler, "params_fixed_by_ancestry", {})
+
+    if step_2_only:
+        return list(range(len(model_base_params)))
+
+    return [
+        idx for idx, (name, info) in enumerate(model_base_params.items())
+        if (
+            info.type != ParamType.SEX_BIAS
+            and name not in user_params_fixed_by_value
+            and name not in params_fixed_by_ancestry
+        )
+    ]
+
+
+def _print_run_intro(parameter_handler: FixedParametersHandler,
+                     model,
+                     start_params_list: list[np.ndarray],
+                     bound_func: Callable[[np.ndarray], float],
+                     title_message: str,
+                     two_steps_optimization: bool,
+                     autosomes_in_step_2: bool,
+                     steps: list[int | str] | None = None) -> None:
+    """
+    Print the optimization subtitle and starting-parameter table for a run.
+
+    This helper centralizes the pre-run console/log output shown before each optimization phase. Time-parameter transition logging is temporarily
+    disabled while printing the starting-parameter table to avoid emitting admissibility transition warnings during display-only conversions.
+
+    Parameters
+    ----------
+    parameter_handler: FixedParametersHandler
+        Parameter handler used for subtitle generation and parameter conversion.
+    model
+        Model object used as fallback metadata source when needed.
+    start_params_list: list[np.ndarray]
+        Starting parameters (in optimizer units) for all runs in the phase.
+    bound_func: Callable[[np.ndarray], float]
+        Bound/violation function used to flag out-of-bounds starts in the
+        table.
+    title_message: str
+        Title printed above the starting-parameter table.
+    two_steps_optimization: bool
+        Whether optimization is single-step or two-step.
+    autosomes_in_step_2: bool
+        In two-step mode, whether step 2 uses autosomal data in addition to
+        allosomal data.
+    steps: list[int | str] | None
+        Active step selection used to compute subtitle and displayed columns.
+    """
+    if hasattr(parameter_handler, "demography"):
+        subtitle_message = _get_optimization_subtitle(
+            parameter_handler=parameter_handler,
+            two_steps_optimization=two_steps_optimization,
+            autosomes_in_step_2=autosomes_in_step_2,
+            steps=steps,
+        )
+    else:
+        all_params = model.model_base_params
+        if not two_steps_optimization:
+            free_params = list(all_params.keys())
+            subtitle_message = f"Optimizing model likelihood over parameters {str(free_params)}."
+        else:
+            normalized_steps = set(steps or [1, 2])
+            if 2 in normalized_steps and 1 not in normalized_steps:
+                free_params = [
+                    name for name, info in all_params.items()
+                    if info.type == ParamType.SEX_BIAS
+                ]
+                step_2_data = "autosomal + allosomal" if autosomes_in_step_2 else "allosomal"
+                subtitle_message = f"Step 2 : Optimizing {step_2_data} likelihood over parameters : {str(free_params)}."
+            else:
+                free_params = [
+                    name for name, info in all_params.items()
+                    if info.type != ParamType.SEX_BIAS
+                ]
+                subtitle_message = f"Step 1 : Optimizing autosomal likelihood over parameters {str(free_params)}."
+
+    for line in ["-" * len(subtitle_message), subtitle_message, "-" * len(subtitle_message)]:
+        print(line)
+        logger.info(line)
+
+    display_param_indices = _get_display_param_indices(
+        parameter_handler=parameter_handler,
+        model=model,
+        two_steps_optimization=two_steps_optimization,
+        steps=steps,
+    )
+
+    prev_time_param_logging = parameter_handler.enable_time_param_logging
+    parameter_handler.enable_time_param_logging = False
+    try:
+        _print_step_header_block(
+            parameter_handler=parameter_handler,
+            start_params_list=start_params_list,
+            bound_func=bound_func,
+            title_message=title_message,
+            display_param_indices=display_param_indices,
+        )
+    finally:
+        parameter_handler.enable_time_param_logging = prev_time_param_logging
+
+
+def _get_optimization_subtitle(parameter_handler: FixedParametersHandler,
+                              two_steps_optimization: bool,
+                              autosomes_in_step_2: bool,
+                              steps: list[int | str] | None = None) -> str:
+    """
+    Build the user-readable optimization subtitle for the active run phase. This helper determines which parameter set is being optimized in the
+    current context and returns the corresponding subtitle string used in console/log headers.
+
+    Behavior
+    --------
+    - Single-step mode: reports all currently free parameters.
+    - Two-step mode, step 2 only: reports sex-bias parameters only.
+    - Two-step mode, otherwise: reports non-sex-bias parameters (step 1 view).
+    - In two-step mode, parameters fixed by value or ancestry are excluded
+      from the displayed list.
+
+    Parameters
+    ----------
+    parameter_handler: FixedParametersHandler
+        Provides parameter metadata and fixed-parameter information.
+    two_steps_optimization: bool
+        Whether optimization is configured to run in two-step mode.
+    autosomes_in_step_2: bool
+        If True, the step-2 subtitle references autosomal + allosomal data;
+        otherwise it references allosomal data only.
+    steps: list[int | str] | None
+        Optional explicit step selection. Accepted labels are ``1``/``"step1"`` and ``2``/``"step2"``. If None, both steps are assumed.
+
+    Returns
+    -------
+    str
+        Subtitle describing the active optimization step and parameter subset.
+    """
+    if not two_steps_optimization:
+        free_params = list(parameter_handler.indices_to_labels(parameter_handler.free_parameters_indices))
+        return f"Optimizing model likelihood over parameters {str(free_params)}."
+
+    normalized_steps = set()
+    if steps is None:
+        normalized_steps = {1, 2}
+    else:
+        for s in steps:
+            if s in [1, "step1"]:
+                normalized_steps.add(1)
+            elif s in [2, "step2"]:
+                normalized_steps.add(2)
+
+    all_params = parameter_handler.demography.model_base_params
+
+    if 2 in normalized_steps and 1 not in normalized_steps:
+        free_params = [
+            name for name, info in all_params.items()
+            if info.type == ParamType.SEX_BIAS
+            and name not in parameter_handler.user_params_fixed_by_value
+            and name not in parameter_handler.params_fixed_by_ancestry
+        ]
+        step_2_data = "autosomal + allosomal" if autosomes_in_step_2 else "allosomal"
+        return f"Step 2 : Optimizing {step_2_data} likelihood over parameters : {str(free_params)}."
+
+    free_params = [
+        name for name, info in all_params.items()
+        if info.type != ParamType.SEX_BIAS
+        and name not in parameter_handler.user_params_fixed_by_value
+        and name not in parameter_handler.params_fixed_by_ancestry
+    ]
+    return f"Step 1 : Optimizing autosomal likelihood over parameters {str(free_params)}."

--- a/tracts/driver_utils.py
+++ b/tracts/driver_utils.py
@@ -1164,7 +1164,7 @@ def output_simulation_data_sex_biased(sample_population: Population,
 
 
 def _summarize_step_results(params_found: list[np.ndarray], likelihoods: list[float], parameter_handler: FixedParametersHandler,
-                            param_names: list[str], step_label: str | None = None) -> tuple[list[np.ndarray], list[float], np.ndarray, float]:
+                            param_names: list[str], step_label: str | None = None) -> tuple[np.ndarray, float]:
     """
     Print per-run optimization results and select the best run.
 


### PR DESCRIPTION
Refines the sex-biased inference pipeline’s two-step optimization so that step 2 can be run on allosomal-only likelihood by default (can be changed by setting `use_autosomes_for_sex_bias=True` in the driver file), while reusing the best non–sex-bias parameters from step 1 and redrawing sex-bias starting values.

Changes:

- Updates driver flow to (a) restrict step 1 starts to non–sex-bias params with sex-bias fixed, then (b) seed step 2 starts using the best step 1 non–sex-bias params while sampling sex-bias params.

- Extends optimization runner APIs to support step selection (steps), toggling autosome inclusion in step 2, and optionally returning a “full-data” likelihood when step 2 is allosome-only.

- Adds/updates tests and documentation/examples for the new step-2 data-scope behavior.
